### PR TITLE
Improve handling of RFC strings

### DIFF
--- a/src/pyscram/py_server_first.c
+++ b/src/pyscram/py_server_first.c
@@ -9,19 +9,60 @@ py_server_first_init(py_server_first_t *self, PyObject *args, PyObject *kwds)
 	PyObject *client_first_obj = NULL;
 	PyObject *salt_obj = NULL;
 	uint64_t iterations = 0;
+	const char *rfc_string = NULL;
 	py_client_first_t *client_first = NULL;
 	py_crypto_datum_t *salt = NULL;
 	char *serialized = NULL;
 	scram_error_t error = {0};
 	scram_resp_t ret;
-	static char *kwlist[] = {"client_first", "salt", "iterations", NULL};
+	static char *kwlist[] = {"client_first", "salt", "iterations", "rfc_string", NULL};
 
-	if (!PyArg_ParseTupleAndKeywords(args, kwds, "OOK", kwlist,
+	if (!PyArg_ParseTupleAndKeywords(args, kwds, "|$OOKs", kwlist,
 					 &client_first_obj, &salt_obj,
-					 &iterations)) {
+					 &iterations, &rfc_string)) {
 		return -1;
 	}
 
+	/* Check for mutually exclusive parameters */
+	if (rfc_string && client_first_obj) {
+		PyErr_SetString(PyExc_ValueError,
+				"Cannot specify both rfc_string and client_first parameters");
+		return -1;
+	}
+
+	if (!rfc_string && !client_first_obj) {
+		PyErr_SetString(PyExc_ValueError,
+				"Must specify either rfc_string or client_first parameter");
+		return -1;
+	}
+
+	if (rfc_string) {
+		/* Parse from RFC string */
+		Py_BEGIN_ALLOW_THREADS
+		ret = scram_deserialize_server_first_message(rfc_string, &self->msg, &error);
+		if (ret == SCRAM_E_SUCCESS) {
+			/* Re-serialize to get a clean RFC string */
+			ret = scram_serialize_server_first_message(self->msg,
+								   &serialized, &error);
+		}
+		Py_END_ALLOW_THREADS
+
+		if (ret != SCRAM_E_SUCCESS) {
+			set_exc_from_scram(ret, &error,
+					   "Failed to parse server first message");
+			return -1;
+		}
+
+		self->rfc_string = PyUnicode_FromString(serialized);
+		free(serialized);
+		if (!self->rfc_string) {
+			return -1;
+		}
+
+		return 0;
+	}
+
+	/* Create new message from parameters */
 	if (!PyObject_IsInstance(client_first_obj,
 				 (PyObject *)&PyClientFirstMessage_Type)) {
 		PyErr_SetString(PyExc_TypeError,
@@ -173,8 +214,8 @@ py_server_first_str(py_server_first_t *self)
 }
 
 PyDoc_STRVAR(py_server_first__doc__,
-"ServerFirstMessage(client_first, salt, iterations)\n"
-"---------------------------------------------------\n\n"
+"ServerFirstMessage(client_first=None, salt=None, iterations=None, rfc_string=None)\n"
+"-----------------------------------------------------------------------------------\n\n"
 "SCRAM server first message as specified in RFC 5802 Section 5.1.\n\n"
 "This message contains the combined nonce (client + server nonces),\n"
 "salt value, and iteration count for PBKDF2 password derivation.\n"
@@ -182,12 +223,21 @@ PyDoc_STRVAR(py_server_first__doc__,
 "the client nonce during initialization.\n\n"
 "Parameters\n"
 "----------\n"
-"client_first : ClientFirstMessage\n"
-"    The client first message to respond to\n"
-"salt : CryptoDatum\n"
-"    Salt value for password derivation\n"
-"iterations : int\n"
-"    Iteration count for PBKDF2 (must be within valid range)\n"
+"client_first : ClientFirstMessage, optional\n"
+"    The client first message to respond to.\n"
+"    Required if rfc_string is not provided.\n"
+"salt : CryptoDatum, optional\n"
+"    Salt value for password derivation.\n"
+"    Required if rfc_string is not provided.\n"
+"iterations : int, optional\n"
+"    Iteration count for PBKDF2 (must be within valid range).\n"
+"    Required if rfc_string is not provided.\n"
+"rfc_string : str, optional\n"
+"    RFC 5802 formatted server-first-message string to parse.\n"
+"    If provided, client_first, salt, and iterations must not be specified.\n\n"
+"Notes\n"
+"-----\n"
+"Either 'client_first' (with salt and iterations) or 'rfc_string' must be provided, but not both.\n"
 );
 
 PyTypeObject PyServerFirstMessage_Type = {

--- a/src/scram/scram_attr_parse.c
+++ b/src/scram/scram_attr_parse.c
@@ -106,7 +106,7 @@ scram_resp_t scram_parse_nonce(const char *str_in,
 
 	// initially set zero since nonce may be a client (32 byte) or server (64 byte) value
 	ret = scram_parse_b64_datum(str_in, 0, datum_out, error);
-	if ((ret == SCRAM_E_SUCCESS) && ((datum_out->size != SCRAM_NONCE_SIZE) ||
+	if ((ret == SCRAM_E_SUCCESS) && ((datum_out->size != SCRAM_NONCE_SIZE) &&
 	    (datum_out->size != SCRAM_NONCE_SIZE * 2))) {
 		scram_set_error(error, "%zu: unexpected nonce size", datum_out->size);
 		crypto_datum_clear(datum_out, false);
@@ -142,10 +142,10 @@ scram_resp_t scram_parse_principal(char *str_in,
 		return SCRAM_E_INVALID_REQUEST;
 	}
 
-	api_key_id_str = strstr(str_in, "=");
+	api_key_id_str = strchr(str_in, ':');
 	if (api_key_id_str != NULL) {
-		*api_key_id_str = '\0';
-		if (*api_key_id_str++ == '\0') {
+		*api_key_id_str++ = '\0';
+		if (*api_key_id_str == '\0') {
 			scram_set_error(error,
 					"%s: expected value after separator (:)",
 					str_in);
@@ -228,7 +228,7 @@ scram_resp_t scram_attr_parse(const char *str_in,
 		}
 		break;
 	case SCRAM_ATTR_SALT_CH:
-		ret = scram_parse_b64_datum(str_in, SCRAM_DEFAULT_SALT_SZ,
+		ret = scram_parse_b64_datum(attr_val, SCRAM_DEFAULT_SALT_SZ,
 					    &attr_out->scram_val.datum,
 					    error);
 		if (ret == SCRAM_E_SUCCESS) {

--- a/src/scram/scram_utils.c
+++ b/src/scram/scram_utils.c
@@ -712,7 +712,7 @@ scram_resp_t scram_base64_decode(const crypto_datum_t *data_in,
 
 	decoded_len = EVP_DecodeBlock(decoded, data_in->data, (int)data_in->size);
 	if (decoded_len < 0) {
-		scram_set_ssl_error(error, "EVP_DecodeBlock() failed");
+		scram_set_ssl_error(error, "EVP_DecodeBlock()");
 		free(decoded);
 		return SCRAM_E_BASE64_ERROR;
 	}

--- a/tests/test_client_final.py
+++ b/tests/test_client_final.py
@@ -16,29 +16,30 @@ def auth_data():
 @pytest.fixture
 def client_first():
     """Generate a client first message for testing."""
-    return truenas_pyscram.ClientFirstMessage("testuser")
+    return truenas_pyscram.ClientFirstMessage(username="testuser")
 
 
 @pytest.fixture
 def client_first_with_gs2():
     """Generate a client first message with GS2 header for testing."""
-    return truenas_pyscram.ClientFirstMessage("testuser",
+    return truenas_pyscram.ClientFirstMessage(username="testuser",
                                               gs2_header="p=tls-unique")
 
 
 @pytest.fixture
 def server_first(client_first, auth_data):
     """Generate a server first message for testing."""
-    return truenas_pyscram.ServerFirstMessage(client_first, auth_data.salt,
-                                              auth_data.iterations)
+    return truenas_pyscram.ServerFirstMessage(client_first=client_first,
+                                              salt=auth_data.salt,
+                                              iterations=auth_data.iterations)
 
 
 @pytest.fixture
 def server_first_with_gs2(client_first_with_gs2, auth_data):
     """Generate a server first message for GS2 client for testing."""
-    return truenas_pyscram.ServerFirstMessage(client_first_with_gs2,
-                                              auth_data.salt,
-                                              auth_data.iterations)
+    return truenas_pyscram.ServerFirstMessage(client_first=client_first_with_gs2,
+                                              salt=auth_data.salt,
+                                              iterations=auth_data.iterations)
 
 
 @pytest.fixture
@@ -50,10 +51,10 @@ def channel_binding():
 def test_client_final_message_creation(client_first, server_first, auth_data):
     """Test that ClientFinalMessage can be created."""
     msg = truenas_pyscram.ClientFinalMessage(
-        client_first,
-        server_first,
-        auth_data.client_key,
-        auth_data.stored_key
+        client_first=client_first,
+        server_first=server_first,
+        client_key=auth_data.client_key,
+        stored_key=auth_data.stored_key
     )
     assert isinstance(msg.nonce, truenas_pyscram.CryptoDatum)
     assert isinstance(msg.client_proof, truenas_pyscram.CryptoDatum)
@@ -72,10 +73,10 @@ def test_client_final_message_property_types(client_first, server_first,
                                              expected_type):
     """Test that ClientFinalMessage properties have correct types."""
     msg = truenas_pyscram.ClientFinalMessage(
-        client_first,
-        server_first,
-        auth_data.client_key,
-        auth_data.stored_key
+        client_first=client_first,
+        server_first=server_first,
+        client_key=auth_data.client_key,
+        stored_key=auth_data.stored_key
     )
     prop_value = getattr(msg, property_name)
     if isinstance(expected_type, tuple):
@@ -89,11 +90,11 @@ def test_client_final_message_with_channel_binding(client_first_with_gs2,
                                                    auth_data, channel_binding):
     """Test ClientFinalMessage creation with channel binding."""
     msg = truenas_pyscram.ClientFinalMessage(
-        client_first_with_gs2,
-        server_first_with_gs2,
-        auth_data.client_key,
-        auth_data.stored_key,
-        channel_binding
+        client_first=client_first_with_gs2,
+        server_first=server_first_with_gs2,
+        client_key=auth_data.client_key,
+        stored_key=auth_data.stored_key,
+        channel_binding=channel_binding
     )
     assert isinstance(msg.nonce, truenas_pyscram.CryptoDatum)
     assert isinstance(msg.client_proof, truenas_pyscram.CryptoDatum)
@@ -106,10 +107,10 @@ def test_client_final_message_nonce_property(client_first, server_first,
                                              auth_data):
     """Test that nonce property returns correct combined nonce."""
     msg = truenas_pyscram.ClientFinalMessage(
-        client_first,
-        server_first,
-        auth_data.client_key,
-        auth_data.stored_key
+        client_first=client_first,
+        server_first=server_first,
+        client_key=auth_data.client_key,
+        stored_key=auth_data.stored_key
     )
     assert isinstance(msg.nonce, truenas_pyscram.CryptoDatum)
     # Nonce should match the server first message nonce
@@ -120,10 +121,10 @@ def test_client_final_message_client_proof_property(client_first, server_first,
                                                     auth_data):
     """Test that client_proof property returns valid proof."""
     msg = truenas_pyscram.ClientFinalMessage(
-        client_first,
-        server_first,
-        auth_data.client_key,
-        auth_data.stored_key
+        client_first=client_first,
+        server_first=server_first,
+        client_key=auth_data.client_key,
+        stored_key=auth_data.stored_key
     )
     assert isinstance(msg.client_proof, truenas_pyscram.CryptoDatum)
     # Client proof should be 64 bytes (SHA-512)
@@ -134,10 +135,10 @@ def test_client_final_message_str_format(client_first, server_first,
                                          auth_data):
     """Test that str() returns RFC 5802 formatted message."""
     msg = truenas_pyscram.ClientFinalMessage(
-        client_first,
-        server_first,
-        auth_data.client_key,
-        auth_data.stored_key
+        client_first=client_first,
+        server_first=server_first,
+        client_key=auth_data.client_key,
+        stored_key=auth_data.stored_key
     )
 
     msg_str = str(msg)
@@ -151,10 +152,10 @@ def test_client_final_message_str_components(client_first, server_first,
                                              auth_data):
     """Test that str() contains correct base64-encoded components."""
     msg = truenas_pyscram.ClientFinalMessage(
-        client_first,
-        server_first,
-        auth_data.client_key,
-        auth_data.stored_key
+        client_first=client_first,
+        server_first=server_first,
+        client_key=auth_data.client_key,
+        stored_key=auth_data.stored_key
     )
 
     msg_str = str(msg)
@@ -194,11 +195,11 @@ def test_client_final_message_str_with_channel_binding(client_first_with_gs2,
                                                        channel_binding):
     """Test str() format with channel binding."""
     msg = truenas_pyscram.ClientFinalMessage(
-        client_first_with_gs2,
-        server_first_with_gs2,
-        auth_data.client_key,
-        auth_data.stored_key,
-        channel_binding
+        client_first=client_first_with_gs2,
+        server_first=server_first_with_gs2,
+        client_key=auth_data.client_key,
+        stored_key=auth_data.stored_key,
+        channel_binding=channel_binding
     )
 
     msg_str = str(msg)
@@ -223,10 +224,10 @@ def test_client_final_message_invalid_client_first(server_first, auth_data,
     """Test ClientFinalMessage with invalid client_first parameter."""
     with pytest.raises(TypeError, match=expected_error):
         truenas_pyscram.ClientFinalMessage(
-            invalid_client_first,
-            server_first,
-            auth_data.client_key,
-            auth_data.stored_key
+            client_first=invalid_client_first,
+            server_first=server_first,
+            client_key=auth_data.client_key,
+            stored_key=auth_data.stored_key
         )
 
 
@@ -242,10 +243,10 @@ def test_client_final_message_invalid_server_first(client_first, auth_data,
     """Test ClientFinalMessage with invalid server_first parameter."""
     with pytest.raises(TypeError, match=expected_error):
         truenas_pyscram.ClientFinalMessage(
-            client_first,
-            invalid_server_first,
-            auth_data.client_key,
-            auth_data.stored_key
+            client_first=client_first,
+            server_first=invalid_server_first,
+            client_key=auth_data.client_key,
+            stored_key=auth_data.stored_key
         )
 
 
@@ -288,11 +289,11 @@ def test_client_final_message_invalid_channel_binding(client_first,
     """Test ClientFinalMessage with invalid channel_binding parameter."""
     with pytest.raises(TypeError, match=expected_error):
         truenas_pyscram.ClientFinalMessage(
-            client_first,
-            server_first,
-            auth_data.client_key,
-            auth_data.stored_key,
-            invalid_channel_binding
+            client_first=client_first,
+            server_first=server_first,
+            client_key=auth_data.client_key,
+            stored_key=auth_data.stored_key,
+            channel_binding=invalid_channel_binding
         )
 
 
@@ -305,10 +306,10 @@ def test_client_final_message_different_auth_data(client_first, server_first):
     messages = []
     for auth_data in auth_data_sets:
         msg = truenas_pyscram.ClientFinalMessage(
-            client_first,
-            server_first,
-            auth_data.client_key,
-            auth_data.stored_key
+            client_first=client_first,
+            server_first=server_first,
+            client_key=auth_data.client_key,
+            stored_key=auth_data.stored_key
         )
         messages.append(msg)
 
@@ -323,18 +324,22 @@ def test_client_final_message_different_auth_data(client_first, server_first):
 
 def test_client_final_message_consistent_nonce(auth_data):
     """Test that ClientFinalMessage uses consistent nonce from server."""
-    client1 = truenas_pyscram.ClientFirstMessage("user1")
-    client2 = truenas_pyscram.ClientFirstMessage("user2")
+    client1 = truenas_pyscram.ClientFirstMessage(username="user1")
+    client2 = truenas_pyscram.ClientFirstMessage(username="user2")
 
-    server1 = truenas_pyscram.ServerFirstMessage(client1, auth_data.salt,
-                                                 auth_data.iterations)
-    server2 = truenas_pyscram.ServerFirstMessage(client2, auth_data.salt,
-                                                 auth_data.iterations)
+    server1 = truenas_pyscram.ServerFirstMessage(client_first=client1,
+                                                 salt=auth_data.salt,
+                                                 iterations=auth_data.iterations)
+    server2 = truenas_pyscram.ServerFirstMessage(client_first=client2,
+                                                 salt=auth_data.salt,
+                                                 iterations=auth_data.iterations)
 
     final1 = truenas_pyscram.ClientFinalMessage(
-        client1, server1, auth_data.client_key, auth_data.stored_key)
+        client_first=client1, server_first=server1,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key)
     final2 = truenas_pyscram.ClientFinalMessage(
-        client2, server2, auth_data.client_key, auth_data.stored_key)
+        client_first=client2, server_first=server2,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key)
 
     # Each final message should use its corresponding server's nonce
     assert bytes(final1.nonce) == bytes(server1.nonce)
@@ -352,15 +357,16 @@ def test_client_final_message_consistent_nonce(auth_data):
 def test_client_final_message_with_different_clients(auth_data, username,
                                                      api_key_id):
     """Test ClientFinalMessage with different client configurations."""
-    client = truenas_pyscram.ClientFirstMessage(username,
+    client = truenas_pyscram.ClientFirstMessage(username=username,
                                                 api_key_id=api_key_id)
-    server = truenas_pyscram.ServerFirstMessage(client, auth_data.salt,
-                                                auth_data.iterations)
+    server = truenas_pyscram.ServerFirstMessage(client_first=client,
+                                                salt=auth_data.salt,
+                                                iterations=auth_data.iterations)
     msg = truenas_pyscram.ClientFinalMessage(
-        client,
-        server,
-        auth_data.client_key,
-        auth_data.stored_key
+        client_first=client,
+        server_first=server,
+        client_key=auth_data.client_key,
+        stored_key=auth_data.stored_key
     )
 
     # Should create valid message regardless of client configuration
@@ -374,11 +380,11 @@ def test_client_final_message_none_channel_binding(client_first, server_first,
                                                    auth_data):
     """Test ClientFinalMessage with explicit None channel binding."""
     msg = truenas_pyscram.ClientFinalMessage(
-        client_first,
-        server_first,
-        auth_data.client_key,
-        auth_data.stored_key,
-        None  # Explicit None
+        client_first=client_first,
+        server_first=server_first,
+        client_key=auth_data.client_key,
+        stored_key=auth_data.stored_key,
+        channel_binding=None  # Explicit None
     )
 
     assert isinstance(msg.nonce, truenas_pyscram.CryptoDatum)

--- a/tests/test_client_first.py
+++ b/tests/test_client_first.py
@@ -7,7 +7,7 @@ import truenas_pyscram
 
 def test_client_first_message_creation():
     """Test that ClientFirstMessage can be created with username."""
-    msg = truenas_pyscram.ClientFirstMessage("testuser")
+    msg = truenas_pyscram.ClientFirstMessage(username="testuser")
     assert msg.username == "testuser"
     assert msg.api_key_id == 0
     assert msg.gs2_header is None
@@ -16,7 +16,7 @@ def test_client_first_message_creation():
 
 def test_client_first_message_with_api_key():
     """Test ClientFirstMessage creation with API key ID."""
-    msg = truenas_pyscram.ClientFirstMessage("testuser", api_key_id=12345)
+    msg = truenas_pyscram.ClientFirstMessage(username="testuser", api_key_id=12345)
     assert msg.username == "testuser"
     assert msg.api_key_id == 12345
     assert msg.gs2_header is None
@@ -25,7 +25,7 @@ def test_client_first_message_with_api_key():
 def test_client_first_message_with_gs2_header():
     """Test ClientFirstMessage creation with GS2 header."""
     gs2_header = "n"  # Standard GS2 header for no channel binding
-    msg = truenas_pyscram.ClientFirstMessage("testuser", gs2_header=gs2_header)
+    msg = truenas_pyscram.ClientFirstMessage(username="testuser", gs2_header=gs2_header)
     assert msg.username == "testuser"
     assert msg.api_key_id == 0
     assert msg.gs2_header == gs2_header
@@ -34,7 +34,7 @@ def test_client_first_message_with_gs2_header():
 def test_client_first_message_with_all_parameters():
     """Test ClientFirstMessage creation with all parameters."""
     msg = truenas_pyscram.ClientFirstMessage(
-        "testuser",
+        username="testuser",
         api_key_id=999,
         gs2_header="n"
     )
@@ -45,7 +45,7 @@ def test_client_first_message_with_all_parameters():
 
 def test_client_first_message_nonce_properties():
     """Test that the client nonce has expected properties."""
-    msg = truenas_pyscram.ClientFirstMessage("testuser")
+    msg = truenas_pyscram.ClientFirstMessage(username="testuser")
 
     # Nonce should be a CryptoDatum
     assert isinstance(msg.nonce, truenas_pyscram.CryptoDatum)
@@ -61,8 +61,8 @@ def test_client_first_message_nonce_properties():
 
 def test_client_first_message_nonce_randomness():
     """Test that different messages have different nonces."""
-    msg1 = truenas_pyscram.ClientFirstMessage("testuser")
-    msg2 = truenas_pyscram.ClientFirstMessage("testuser")
+    msg1 = truenas_pyscram.ClientFirstMessage(username="testuser")
+    msg2 = truenas_pyscram.ClientFirstMessage(username="testuser")
 
     # Nonces should be different (extremely unlikely to be same with crypto)
     assert msg1.nonce != msg2.nonce
@@ -70,7 +70,7 @@ def test_client_first_message_nonce_randomness():
 
 def test_client_first_message_serialization():
     """Test that ClientFirstMessage can be serialized to string."""
-    msg = truenas_pyscram.ClientFirstMessage("testuser")
+    msg = truenas_pyscram.ClientFirstMessage(username="testuser")
 
     # Should be able to convert to string
     serialized = str(msg)
@@ -83,7 +83,7 @@ def test_client_first_message_serialization():
 
 def test_client_first_message_serialization_with_api_key():
     """Test serialization with API key ID includes colon delimiter."""
-    msg = truenas_pyscram.ClientFirstMessage("testuser", api_key_id=123)
+    msg = truenas_pyscram.ClientFirstMessage(username="testuser", api_key_id=123)
     serialized = str(msg)
 
     # Should contain username with colon delimiter for API key
@@ -92,7 +92,7 @@ def test_client_first_message_serialization_with_api_key():
 
 def test_client_first_message_repr():
     """Test ClientFirstMessage repr format."""
-    msg = truenas_pyscram.ClientFirstMessage("testuser", api_key_id=456)
+    msg = truenas_pyscram.ClientFirstMessage(username="testuser", api_key_id=456)
     repr_str = repr(msg)
 
     assert "ClientFirstMessage" in repr_str
@@ -102,14 +102,14 @@ def test_client_first_message_repr():
 
 def test_client_first_message_type():
     """Test that ClientFirstMessage returns expected type."""
-    msg = truenas_pyscram.ClientFirstMessage("testuser")
+    msg = truenas_pyscram.ClientFirstMessage(username="testuser")
     assert type(msg).__name__ == "ClientFirstMessage"
 
 
 def test_client_first_message_with_empty_username():
     """Test ClientFirstMessage with empty username."""
     # Empty username should still work (validation is handled by C library)
-    msg = truenas_pyscram.ClientFirstMessage("")
+    msg = truenas_pyscram.ClientFirstMessage(username="")
     assert msg.username == ""
     assert isinstance(msg.nonce, truenas_pyscram.CryptoDatum)
 
@@ -117,7 +117,7 @@ def test_client_first_message_with_empty_username():
 def test_client_first_message_multiple_creation():
     """Test creating multiple ClientFirstMessage instances."""
     messages = [
-        truenas_pyscram.ClientFirstMessage(f"user{i}", api_key_id=i)
+        truenas_pyscram.ClientFirstMessage(username=f"user{i}", api_key_id=i)
         for i in range(5)
     ]
 
@@ -135,7 +135,7 @@ def test_client_first_message_multiple_creation():
 
 def test_client_first_rfc5802_format_no_gs2():
     """Test str() output matches actual serialization behavior."""
-    msg = truenas_pyscram.ClientFirstMessage("alice")
+    msg = truenas_pyscram.ClientFirstMessage(username="alice")
     serialized = str(msg)
 
     # Current behavior: default GS2 header "n,," is added
@@ -160,7 +160,7 @@ def test_client_first_rfc5802_format_no_gs2():
 
 def test_client_first_rfc5802_format_with_api_key():
     """Test RFC 5802 format with API key ID."""
-    msg = truenas_pyscram.ClientFirstMessage("bob", api_key_id=456)
+    msg = truenas_pyscram.ClientFirstMessage(username="bob", api_key_id=456)
     serialized = str(msg)
 
     # Default GS2 header is added
@@ -183,7 +183,7 @@ def test_client_first_rfc5802_format_with_api_key():
 
 def test_client_first_rfc5802_gs2_header():
     """Test proper RFC 5802 GS2 header behavior."""
-    msg = truenas_pyscram.ClientFirstMessage("charlie", gs2_header="n")
+    msg = truenas_pyscram.ClientFirstMessage(username="charlie", gs2_header="n")
     serialized = str(msg)
 
     # Should now properly format: gs2-header + separator + attributes
@@ -208,7 +208,7 @@ def test_client_first_rfc5802_gs2_header():
 
 def test_client_first_api_key_with_gs2_header():
     """Test API key handling with explicit GS2 header."""
-    msg = truenas_pyscram.ClientFirstMessage("dave", api_key_id=789,
+    msg = truenas_pyscram.ClientFirstMessage(username="dave", api_key_id=789,
                                              gs2_header="n")
     serialized = str(msg)
 
@@ -230,7 +230,7 @@ def test_client_first_api_key_with_gs2_header():
 
 def test_client_first_message_attributes_parsing():
     """Test that we can extract username and nonce from serialized form."""
-    msg = truenas_pyscram.ClientFirstMessage("eve", api_key_id=999)
+    msg = truenas_pyscram.ClientFirstMessage(username="eve", api_key_id=999)
     serialized = str(msg)
 
     # For messages without explicit GS2 header, we get proper separator

--- a/tests/test_rfc_parsing.py
+++ b/tests/test_rfc_parsing.py
@@ -1,0 +1,341 @@
+"""Tests for RFC string parsing functionality in SCRAM messages."""
+
+import pytest
+import truenas_pyscram as scram
+
+
+def test_client_first_parse_basic():
+    """Test parsing a basic client-first-message from RFC string."""
+    msg1 = scram.ClientFirstMessage(username="testuser")
+    rfc_str = str(msg1)
+
+    msg2 = scram.ClientFirstMessage(rfc_string=rfc_str)
+
+    assert str(msg1) == str(msg2)
+    assert msg2.username == "testuser"
+    assert msg2.api_key_id == 0
+
+
+def test_client_first_parse_with_api_key():
+    """Test parsing client-first-message with API key ID."""
+    msg1 = scram.ClientFirstMessage(username="testuser", api_key_id=12345)
+    rfc_str = str(msg1)
+    api_user_str = 'testuser:12345'
+
+    assert api_user_str in rfc_str
+
+    msg2 = scram.ClientFirstMessage(rfc_string=rfc_str)
+
+    assert str(msg1) == str(msg2)
+    assert msg2.api_key_id == 12345
+    assert msg2.username == "testuser"
+
+
+def test_client_first_parse_with_gs2_header():
+    """Test parsing client-first-message with GS2 header."""
+    msg1 = scram.ClientFirstMessage(username="testuser", gs2_header="p=tls-unique")
+    rfc_str = str(msg1)
+
+    msg2 = scram.ClientFirstMessage(rfc_string=rfc_str)
+
+    assert str(msg1) == str(msg2)
+    assert msg2.username == "testuser"
+    assert msg2.gs2_header == "p=tls-unique"
+
+
+def test_client_first_no_params_error():
+    """Test that ClientFirstMessage requires either username or rfc_string."""
+    with pytest.raises(ValueError, match="Must specify either rfc_string or username"):
+        scram.ClientFirstMessage()
+
+
+def test_client_first_conflicting_params_error():
+    """Test that username and rfc_string are mutually exclusive."""
+    with pytest.raises(ValueError, match="Cannot specify both rfc_string and username"):
+        scram.ClientFirstMessage(username="test", rfc_string="n,,n=test,r=xxx")
+
+
+def test_server_first_parse_basic():
+    """Test parsing a basic server-first-message from RFC string."""
+    client_first = scram.ClientFirstMessage(username="testuser")
+    auth_data_for_salt = scram.generate_scram_auth_data()
+    salt = auth_data_for_salt.salt
+
+    msg1 = scram.ServerFirstMessage(
+        client_first=client_first,
+        salt=salt,
+        iterations=100000
+    )
+    rfc_str = str(msg1)
+
+    try:
+        msg2 = scram.ServerFirstMessage(rfc_string=rfc_str)
+    except Exception as exc:
+        raise RuntimeError(f'Failed to decode ({rfc_str}): {exc}')
+
+    assert str(msg1) == str(msg2)
+    assert msg2.iterations == 100000
+
+
+@pytest.mark.parametrize("iterations", [100000, 600000])
+def test_server_first_parse_various_iterations(iterations):
+    """Test parsing server-first-message with various iteration counts."""
+    client_first = scram.ClientFirstMessage(username="testuser")
+    auth_data_for_salt = scram.generate_scram_auth_data()
+    salt = auth_data_for_salt.salt
+
+    msg1 = scram.ServerFirstMessage(
+        client_first=client_first,
+        salt=salt,
+        iterations=iterations
+    )
+    rfc_str = str(msg1)
+
+    msg2 = scram.ServerFirstMessage(rfc_string=rfc_str)
+
+    assert str(msg1) == str(msg2)
+    assert msg2.iterations == iterations
+
+
+def test_server_first_no_params_error():
+    """Test that ServerFirstMessage requires either client_first or rfc_string."""
+    with pytest.raises(ValueError, match="Must specify either rfc_string or client_first"):
+        scram.ServerFirstMessage()
+
+
+def test_server_first_conflicting_params_error():
+    """Test that client_first and rfc_string are mutually exclusive."""
+    client_first = scram.ClientFirstMessage(username="test")
+    auth_data_for_salt = scram.generate_scram_auth_data()
+    salt = auth_data_for_salt.salt
+
+    with pytest.raises(ValueError, match="Cannot specify both rfc_string and client_first"):
+        scram.ServerFirstMessage(
+            client_first=client_first,
+            salt=salt,
+            iterations=200000,
+            rfc_string="r=xxx,s=yyy,i=4096"
+        )
+
+
+@pytest.fixture
+def client_server_first_messages():
+    """Create client_first and server_first messages for testing."""
+    client_first = scram.ClientFirstMessage(username="testuser")
+    auth_data_for_salt = scram.generate_scram_auth_data()
+    salt = auth_data_for_salt.salt
+    server_first = scram.ServerFirstMessage(
+        client_first=client_first,
+        salt=salt,
+        iterations=200000
+    )
+    auth_data = scram.generate_scram_auth_data(salt=salt, iterations=200000)
+    return client_first, server_first, auth_data
+
+
+def test_client_final_parse_basic(client_server_first_messages):
+    """Test parsing a basic client-final-message from RFC string."""
+    client_first, server_first, auth_data = client_server_first_messages
+
+    msg1 = scram.ClientFinalMessage(
+        client_first=client_first,
+        server_first=server_first,
+        client_key=auth_data.client_key,
+        stored_key=auth_data.stored_key
+    )
+    rfc_str = str(msg1)
+
+    msg2 = scram.ClientFinalMessage(rfc_string=rfc_str)
+
+    assert str(msg1) == str(msg2)
+
+
+def test_client_final_parse_with_channel_binding(client_server_first_messages):
+    """Test parsing client-final-message with channel binding."""
+    client_first, server_first, auth_data = client_server_first_messages
+
+    channel_binding = scram.CryptoDatum(b"test-channel-binding-data")
+
+    msg1 = scram.ClientFinalMessage(
+        client_first=client_first,
+        server_first=server_first,
+        client_key=auth_data.client_key,
+        stored_key=auth_data.stored_key,
+        channel_binding=channel_binding
+    )
+    rfc_str = str(msg1)
+
+    msg2 = scram.ClientFinalMessage(rfc_string=rfc_str)
+
+    assert str(msg1) == str(msg2)
+
+
+def test_client_final_no_params_error():
+    """Test that ClientFinalMessage requires parameters."""
+    with pytest.raises(ValueError, match="Must specify either rfc_string or message parameters"):
+        scram.ClientFinalMessage()
+
+
+def test_client_final_conflicting_params_error(client_server_first_messages):
+    """Test that message params and rfc_string are mutually exclusive."""
+    client_first, server_first, auth_data = client_server_first_messages
+
+    with pytest.raises(ValueError, match="Cannot specify both rfc_string and other parameters"):
+        scram.ClientFinalMessage(
+            client_first=client_first,
+            server_first=server_first,
+            client_key=auth_data.client_key,
+            stored_key=auth_data.stored_key,
+            rfc_string="c=biws,r=xxx,p=yyy"
+        )
+
+
+@pytest.fixture
+def all_messages():
+    """Create all messages needed for server final testing."""
+    client_first = scram.ClientFirstMessage(username="testuser")
+    auth_data_for_salt = scram.generate_scram_auth_data()
+    salt = auth_data_for_salt.salt
+    server_first = scram.ServerFirstMessage(
+        client_first=client_first,
+        salt=salt,
+        iterations=200000
+    )
+    auth_data = scram.generate_scram_auth_data(salt=salt, iterations=200000)
+    client_final = scram.ClientFinalMessage(
+        client_first=client_first,
+        server_first=server_first,
+        client_key=auth_data.client_key,
+        stored_key=auth_data.stored_key
+    )
+    return client_first, server_first, client_final, auth_data
+
+
+def test_server_final_parse_basic(all_messages):
+    """Test parsing a basic server-final-message from RFC string."""
+    client_first, server_first, client_final, auth_data = all_messages
+
+    msg1 = scram.ServerFinalMessage(
+        client_first=client_first,
+        server_first=server_first,
+        client_final=client_final,
+        stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key
+    )
+    rfc_str = str(msg1)
+
+    msg2 = scram.ServerFinalMessage(rfc_string=rfc_str)
+
+    assert str(msg1) == str(msg2)
+
+
+def test_server_final_no_params_error():
+    """Test that ServerFinalMessage requires parameters."""
+    with pytest.raises(ValueError, match="Must specify either rfc_string or message parameters"):
+        scram.ServerFinalMessage()
+
+
+def test_server_final_conflicting_params_error(all_messages):
+    """Test that message params and rfc_string are mutually exclusive."""
+    client_first, server_first, client_final, auth_data = all_messages
+
+    with pytest.raises(ValueError, match="Cannot specify both rfc_string and other parameters"):
+        scram.ServerFinalMessage(
+            client_first=client_first,
+            server_first=server_first,
+            client_final=client_final,
+            stored_key=auth_data.stored_key,
+            server_key=auth_data.server_key,
+            rfc_string="v=xxx"
+        )
+
+
+def test_complete_auth_flow_roundtrip():
+    """Test that a complete auth flow can be serialized and deserialized."""
+    # Create initial client message
+    client_first_1 = scram.ClientFirstMessage(username="alice", api_key_id=999)
+    cf1_str = str(client_first_1)
+
+    # Parse it back
+    client_first_2 = scram.ClientFirstMessage(rfc_string=cf1_str)
+    assert str(client_first_1) == str(client_first_2)
+
+    # Create server response
+    auth_data_for_salt = scram.generate_scram_auth_data()
+    salt = auth_data_for_salt.salt
+    server_first_1 = scram.ServerFirstMessage(
+        client_first=client_first_2,
+        salt=salt,
+        iterations=200000
+    )
+    sf1_str = str(server_first_1)
+
+    # Parse server response
+    server_first_2 = scram.ServerFirstMessage(rfc_string=sf1_str)
+    assert str(server_first_1) == str(server_first_2)
+
+    # Create client final
+    auth_data = scram.generate_scram_auth_data(salt=salt, iterations=200000)
+    client_final_1 = scram.ClientFinalMessage(
+        client_first=client_first_1,
+        server_first=server_first_1,
+        client_key=auth_data.client_key,
+        stored_key=auth_data.stored_key
+    )
+    cf2_str = str(client_final_1)
+
+    # Parse client final
+    client_final_2 = scram.ClientFinalMessage(rfc_string=cf2_str)
+    assert str(client_final_1) == str(client_final_2)
+
+    # Create server final
+    server_final_1 = scram.ServerFinalMessage(
+        client_first=client_first_1,
+        server_first=server_first_1,
+        client_final=client_final_1,
+        stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key
+    )
+    sf2_str = str(server_final_1)
+
+    # Parse server final
+    server_final_2 = scram.ServerFinalMessage(rfc_string=sf2_str)
+    assert str(server_final_1) == str(server_final_2)
+
+
+@pytest.mark.parametrize("username", [
+    "simple",
+    "user.with.dots",
+    "user-with-dashes",
+    "user_with_underscores",
+    "user123",
+    "123user",
+])
+def test_various_usernames_roundtrip(username):
+    """Test that various username formats are preserved correctly."""
+    msg1 = scram.ClientFirstMessage(username=username)
+    rfc_str = str(msg1)
+
+    msg2 = scram.ClientFirstMessage(rfc_string=rfc_str)
+
+    assert str(msg1) == str(msg2)
+    assert msg2.username == username
+
+
+@pytest.mark.parametrize("username,api_key_id", [
+    ("user1", 0),
+    ("user2", 1),
+    ("user3", 100),
+    ("user4", 65535),
+    ("user5", 2147483647),
+])
+def test_username_api_key_combinations(username, api_key_id):
+    """Test various combinations of username and API key ID."""
+    msg1 = scram.ClientFirstMessage(username=username, api_key_id=api_key_id)
+    rfc_str = str(msg1)
+
+    msg2 = scram.ClientFirstMessage(rfc_string=rfc_str)
+
+    assert str(msg1) == str(msg2)
+    assert msg2.username == username
+    assert msg2.api_key_id == api_key_id

--- a/tests/test_server_final.py
+++ b/tests/test_server_final.py
@@ -16,33 +16,35 @@ def auth_data():
 @pytest.fixture
 def client_first():
     """Generate a client first message for testing."""
-    return truenas_pyscram.ClientFirstMessage("testuser")
+    return truenas_pyscram.ClientFirstMessage(username="testuser")
 
 
 @pytest.fixture
 def server_first(client_first, auth_data):
     """Generate a server first message for testing."""
-    return truenas_pyscram.ServerFirstMessage(client_first, auth_data.salt,
-                                              auth_data.iterations)
+    return truenas_pyscram.ServerFirstMessage(client_first=client_first,
+                                              salt=auth_data.salt,
+                                              iterations=auth_data.iterations)
 
 
 @pytest.fixture
 def client_final(client_first, server_first, auth_data):
     """Generate a client final message for testing."""
-    return truenas_pyscram.ClientFinalMessage(client_first, server_first,
-                                              auth_data.client_key,
-                                              auth_data.stored_key)
+    return truenas_pyscram.ClientFinalMessage(client_first=client_first,
+                                              server_first=server_first,
+                                              client_key=auth_data.client_key,
+                                              stored_key=auth_data.stored_key)
 
 
 def test_server_final_message_creation(client_first, server_first,
                                        client_final, auth_data):
     """Test that ServerFinalMessage can be created."""
     msg = truenas_pyscram.ServerFinalMessage(
-        client_first,
-        server_first,
-        client_final,
-        auth_data.stored_key,
-        auth_data.server_key
+        client_first=client_first,
+        server_first=server_first,
+        client_final=client_final,
+        stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key
     )
     assert isinstance(msg.signature, truenas_pyscram.CryptoDatum)
 
@@ -51,11 +53,11 @@ def test_server_final_message_signature_property(client_first, server_first,
                                                  client_final, auth_data):
     """Test that signature property returns valid server signature."""
     msg = truenas_pyscram.ServerFinalMessage(
-        client_first,
-        server_first,
-        client_final,
-        auth_data.stored_key,
-        auth_data.server_key
+        client_first=client_first,
+        server_first=server_first,
+        client_final=client_final,
+        stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key
     )
     assert isinstance(msg.signature, truenas_pyscram.CryptoDatum)
     # Server signature should be 64 bytes (SHA-512)
@@ -66,11 +68,11 @@ def test_server_final_message_str_format(client_first, server_first,
                                          client_final, auth_data):
     """Test that str() returns RFC 5802 formatted message."""
     msg = truenas_pyscram.ServerFinalMessage(
-        client_first,
-        server_first,
-        client_final,
-        auth_data.stored_key,
-        auth_data.server_key
+        client_first=client_first,
+        server_first=server_first,
+        client_final=client_final,
+        stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key
     )
 
     msg_str = str(msg)
@@ -84,11 +86,11 @@ def test_server_final_message_str_components(client_first, server_first,
                                              client_final, auth_data):
     """Test that str() contains correct base64-encoded signature."""
     msg = truenas_pyscram.ServerFinalMessage(
-        client_first,
-        server_first,
-        client_final,
-        auth_data.stored_key,
-        auth_data.server_key
+        client_first=client_first,
+        server_first=server_first,
+        client_final=client_final,
+        stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key
     )
 
     msg_str = str(msg)
@@ -115,11 +117,11 @@ def test_server_final_message_invalid_client_first(server_first, client_final,
     """Test ServerFinalMessage with invalid client_first parameter."""
     with pytest.raises(TypeError, match=expected_error):
         truenas_pyscram.ServerFinalMessage(
-            invalid_client_first,
-            server_first,
-            client_final,
-            auth_data.stored_key,
-            auth_data.server_key
+            client_first=invalid_client_first,
+            server_first=server_first,
+            client_final=client_final,
+            stored_key=auth_data.stored_key,
+            server_key=auth_data.server_key
         )
 
 
@@ -136,11 +138,11 @@ def test_server_final_message_invalid_server_first(client_first, client_final,
     """Test ServerFinalMessage with invalid server_first parameter."""
     with pytest.raises(TypeError, match=expected_error):
         truenas_pyscram.ServerFinalMessage(
-            client_first,
-            invalid_server_first,
-            client_final,
-            auth_data.stored_key,
-            auth_data.server_key
+            client_first=client_first,
+            server_first=invalid_server_first,
+            client_final=client_final,
+            stored_key=auth_data.stored_key,
+            server_key=auth_data.server_key
         )
 
 
@@ -157,11 +159,11 @@ def test_server_final_message_invalid_client_final(client_first, server_first,
     """Test ServerFinalMessage with invalid client_final parameter."""
     with pytest.raises(TypeError, match=expected_error):
         truenas_pyscram.ServerFinalMessage(
-            client_first,
-            server_first,
-            invalid_client_final,
-            auth_data.stored_key,
-            auth_data.server_key
+            client_first=client_first,
+            server_first=server_first,
+            client_final=invalid_client_final,
+            stored_key=auth_data.stored_key,
+            server_key=auth_data.server_key
         )
 
 
@@ -203,11 +205,11 @@ def test_server_final_message_different_auth_data(client_first, server_first,
     messages = []
     for auth_data in auth_data_sets:
         msg = truenas_pyscram.ServerFinalMessage(
-            client_first,
-            server_first,
-            client_final,
-            auth_data.stored_key,
-            auth_data.server_key
+            client_first=client_first,
+            server_first=server_first,
+            client_final=client_final,
+            stored_key=auth_data.stored_key,
+            server_key=auth_data.server_key
         )
         messages.append(msg)
 
@@ -222,17 +224,21 @@ def test_server_final_message_consistent_with_same_auth(client_first,
     """Test that ServerFinalMessage is consistent with same auth data."""
     # Create two client final messages with same auth data
     client_final1 = truenas_pyscram.ClientFinalMessage(
-        client_first, server_first, auth_data.client_key, auth_data.stored_key)
+        client_first=client_first, server_first=server_first,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key)
     client_final2 = truenas_pyscram.ClientFinalMessage(
-        client_first, server_first, auth_data.client_key, auth_data.stored_key)
+        client_first=client_first, server_first=server_first,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key)
 
     # Create server final messages
     server_final1 = truenas_pyscram.ServerFinalMessage(
-        client_first, server_first, client_final1,
-        auth_data.stored_key, auth_data.server_key)
+        client_first=client_first, server_first=server_first,
+        client_final=client_final1, stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key)
     server_final2 = truenas_pyscram.ServerFinalMessage(
-        client_first, server_first, client_final2,
-        auth_data.stored_key, auth_data.server_key)
+        client_first=client_first, server_first=server_first,
+        client_final=client_final2, stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key)
 
     # Server signatures should be the same (same auth message)
     assert bytes(server_final1.signature) == bytes(server_final2.signature)
@@ -242,20 +248,23 @@ def test_server_final_message_different_clients(auth_data):
     """Test ServerFinalMessage with different client configurations."""
     # Create different clients
     clients = [
-        truenas_pyscram.ClientFirstMessage("user1"),
-        truenas_pyscram.ClientFirstMessage("user2", api_key_id=123),
-        truenas_pyscram.ClientFirstMessage("admin", api_key_id=999),
+        truenas_pyscram.ClientFirstMessage(username="user1"),
+        truenas_pyscram.ClientFirstMessage(username="user2", api_key_id=123),
+        truenas_pyscram.ClientFirstMessage(username="admin", api_key_id=999),
     ]
 
     messages = []
     for client in clients:
         server_first = truenas_pyscram.ServerFirstMessage(
-            client, auth_data.salt, auth_data.iterations)
+            client_first=client, salt=auth_data.salt,
+            iterations=auth_data.iterations)
         client_final = truenas_pyscram.ClientFinalMessage(
-            client, server_first, auth_data.client_key, auth_data.stored_key)
+            client_first=client, server_first=server_first,
+            client_key=auth_data.client_key, stored_key=auth_data.stored_key)
         server_final = truenas_pyscram.ServerFinalMessage(
-            client, server_first, client_final,
-            auth_data.stored_key, auth_data.server_key)
+            client_first=client, server_first=server_first,
+            client_final=client_final, stored_key=auth_data.stored_key,
+            server_key=auth_data.server_key)
         messages.append(server_final)
 
     # All should be valid but have different signatures (different auth messages)  # noqa: E501
@@ -272,29 +281,34 @@ def test_server_final_message_with_channel_binding(auth_data):
     """Test ServerFinalMessage with channel binding."""
     # Create client with channel binding
     client_first = truenas_pyscram.ClientFirstMessage(
-        "testuser", gs2_header="p=tls-unique")
+        username="testuser", gs2_header="p=tls-unique")
     server_first = truenas_pyscram.ServerFirstMessage(
-        client_first, auth_data.salt, auth_data.iterations)
+        client_first=client_first, salt=auth_data.salt,
+        iterations=auth_data.iterations)
 
     # Create channel binding data
     channel_binding = truenas_pyscram.CryptoDatum(b"fake_channel_binding_data")
 
     client_final = truenas_pyscram.ClientFinalMessage(
-        client_first, server_first, auth_data.client_key,
-        auth_data.stored_key, channel_binding)
+        client_first=client_first, server_first=server_first,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key,
+        channel_binding=channel_binding)
     server_final = truenas_pyscram.ServerFinalMessage(
-        client_first, server_first, client_final,
-        auth_data.stored_key, auth_data.server_key)
+        client_first=client_first, server_first=server_first,
+        client_final=client_final, stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key)
 
     assert isinstance(server_final.signature, truenas_pyscram.CryptoDatum)
     assert len(bytes(server_final.signature)) == 64
 
     # Should produce different signature than without channel binding
     client_final_no_cb = truenas_pyscram.ClientFinalMessage(
-        client_first, server_first, auth_data.client_key, auth_data.stored_key)
+        client_first=client_first, server_first=server_first,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key)
     server_final_no_cb = truenas_pyscram.ServerFinalMessage(
-        client_first, server_first, client_final_no_cb,
-        auth_data.stored_key, auth_data.server_key)
+        client_first=client_first, server_first=server_first,
+        client_final=client_final_no_cb, stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key)
 
     assert bytes(server_final.signature) != bytes(server_final_no_cb.signature)
 
@@ -302,14 +316,17 @@ def test_server_final_message_with_channel_binding(auth_data):
 def test_server_final_message_full_scram_flow(auth_data):
     """Test ServerFinalMessage in complete SCRAM authentication flow."""
     # Complete SCRAM flow
-    client_first = truenas_pyscram.ClientFirstMessage("testuser")
+    client_first = truenas_pyscram.ClientFirstMessage(username="testuser")
     server_first = truenas_pyscram.ServerFirstMessage(
-        client_first, auth_data.salt, auth_data.iterations)
+        client_first=client_first, salt=auth_data.salt,
+        iterations=auth_data.iterations)
     client_final = truenas_pyscram.ClientFinalMessage(
-        client_first, server_first, auth_data.client_key, auth_data.stored_key)
+        client_first=client_first, server_first=server_first,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key)
     server_final = truenas_pyscram.ServerFinalMessage(
-        client_first, server_first, client_final,
-        auth_data.stored_key, auth_data.server_key)
+        client_first=client_first, server_first=server_first,
+        client_final=client_final, stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key)
 
     # Verify all messages are properly formatted
     assert str(client_first).startswith("n,,n=testuser,r=")
@@ -331,15 +348,18 @@ def test_server_final_message_full_scram_flow(auth_data):
 def test_server_final_message_parametrized_clients(auth_data, username,
                                                    api_key_id):
     """Test ServerFinalMessage with parametrized client configurations."""
-    client = truenas_pyscram.ClientFirstMessage(username,
+    client = truenas_pyscram.ClientFirstMessage(username=username,
                                                 api_key_id=api_key_id)
     server_first = truenas_pyscram.ServerFirstMessage(
-        client, auth_data.salt, auth_data.iterations)
+        client_first=client, salt=auth_data.salt,
+        iterations=auth_data.iterations)
     client_final = truenas_pyscram.ClientFinalMessage(
-        client, server_first, auth_data.client_key, auth_data.stored_key)
+        client_first=client, server_first=server_first,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key)
     msg = truenas_pyscram.ServerFinalMessage(
-        client, server_first, client_final,
-        auth_data.stored_key, auth_data.server_key)
+        client_first=client, server_first=server_first,
+        client_final=client_final, stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key)
 
     # Should create valid message regardless of client configuration
     assert isinstance(msg.signature, truenas_pyscram.CryptoDatum)

--- a/tests/test_server_first.py
+++ b/tests/test_server_first.py
@@ -16,15 +16,15 @@ def auth_data():
 @pytest.fixture
 def client_first():
     """Generate a client first message for testing."""
-    return truenas_pyscram.ClientFirstMessage("testuser")
+    return truenas_pyscram.ClientFirstMessage(username="testuser")
 
 
 def test_server_first_message_creation(client_first, auth_data):
     """Test that ServerFirstMessage can be created."""
     msg = truenas_pyscram.ServerFirstMessage(
-        client_first,
-        auth_data.salt,
-        auth_data.iterations
+        client_first=client_first,
+        salt=auth_data.salt,
+        iterations=auth_data.iterations
     )
     assert isinstance(msg.salt, truenas_pyscram.CryptoDatum)
     assert isinstance(msg.nonce, truenas_pyscram.CryptoDatum)
@@ -40,9 +40,9 @@ def test_server_first_message_property_types(client_first, auth_data,
                                              property_name, expected_type):
     """Test that ServerFirstMessage properties have correct types."""
     msg = truenas_pyscram.ServerFirstMessage(
-        client_first,
-        auth_data.salt,
-        auth_data.iterations
+        client_first=client_first,
+        salt=auth_data.salt,
+        iterations=auth_data.iterations
     )
     assert isinstance(getattr(msg, property_name), expected_type)
 
@@ -50,9 +50,9 @@ def test_server_first_message_property_types(client_first, auth_data,
 def test_server_first_message_salt_property(client_first, auth_data):
     """Test that salt property returns the correct CryptoDatum."""
     msg = truenas_pyscram.ServerFirstMessage(
-        client_first,
-        auth_data.salt,
-        auth_data.iterations
+        client_first=client_first,
+        salt=auth_data.salt,
+        iterations=auth_data.iterations
     )
     assert isinstance(msg.salt, truenas_pyscram.CryptoDatum)
     assert bytes(msg.salt) == bytes(auth_data.salt)
@@ -61,9 +61,9 @@ def test_server_first_message_salt_property(client_first, auth_data):
 def test_server_first_message_iterations_property(client_first, auth_data):
     """Test that iterations property returns the correct value."""
     msg = truenas_pyscram.ServerFirstMessage(
-        client_first,
-        auth_data.salt,
-        auth_data.iterations
+        client_first=client_first,
+        salt=auth_data.salt,
+        iterations=auth_data.iterations
     )
     assert msg.iterations == auth_data.iterations
 
@@ -71,9 +71,9 @@ def test_server_first_message_iterations_property(client_first, auth_data):
 def test_server_first_message_nonce_property(client_first, auth_data):
     """Test that nonce is a CryptoDatum and contains client nonce."""
     msg = truenas_pyscram.ServerFirstMessage(
-        client_first,
-        auth_data.salt,
-        auth_data.iterations
+        client_first=client_first,
+        salt=auth_data.salt,
+        iterations=auth_data.iterations
     )
     assert isinstance(msg.nonce, truenas_pyscram.CryptoDatum)
 
@@ -89,9 +89,9 @@ def test_server_first_message_nonce_property(client_first, auth_data):
 def test_server_first_message_nonce_length(client_first, auth_data):
     """Test that combined nonce has expected length."""
     msg = truenas_pyscram.ServerFirstMessage(
-        client_first,
-        auth_data.salt,
-        auth_data.iterations
+        client_first=client_first,
+        salt=auth_data.salt,
+        iterations=auth_data.iterations
     )
 
     # Combined nonce should be client nonce + server nonce
@@ -103,9 +103,9 @@ def test_server_first_message_nonce_length(client_first, auth_data):
 def test_server_first_message_str_format(client_first, auth_data):
     """Test that str() returns RFC 5802 formatted message."""
     msg = truenas_pyscram.ServerFirstMessage(
-        client_first,
-        auth_data.salt,
-        auth_data.iterations
+        client_first=client_first,
+        salt=auth_data.salt,
+        iterations=auth_data.iterations
     )
 
     msg_str = str(msg)
@@ -118,9 +118,9 @@ def test_server_first_message_str_format(client_first, auth_data):
 def test_server_first_message_str_components(client_first, auth_data):
     """Test that str() contains correct base64-encoded components."""
     msg = truenas_pyscram.ServerFirstMessage(
-        client_first,
-        auth_data.salt,
-        auth_data.iterations
+        client_first=client_first,
+        salt=auth_data.salt,
+        iterations=auth_data.iterations
     )
 
     msg_str = str(msg)
@@ -155,9 +155,9 @@ def test_server_first_message_different_iterations(client_first, auth_data,
                                                    iterations):
     """Test ServerFirstMessage with different iteration counts."""
     msg = truenas_pyscram.ServerFirstMessage(
-        client_first,
-        auth_data.salt,
-        iterations
+        client_first=client_first,
+        salt=auth_data.salt,
+        iterations=iterations
     )
     assert msg.iterations == iterations
 
@@ -177,9 +177,9 @@ def test_server_first_message_invalid_client_first(auth_data,
     """Test ServerFirstMessage with invalid client_first parameter."""
     with pytest.raises(TypeError, match=expected_error):
         truenas_pyscram.ServerFirstMessage(
-            invalid_client_first,
-            auth_data.salt,
-            auth_data.iterations
+            client_first=invalid_client_first,
+            salt=auth_data.salt,
+            iterations=auth_data.iterations
         )
 
 
@@ -194,9 +194,9 @@ def test_server_first_message_invalid_salt(client_first, auth_data,
     """Test ServerFirstMessage with invalid salt parameter."""
     with pytest.raises(TypeError, match=expected_error):
         truenas_pyscram.ServerFirstMessage(
-            client_first,
-            invalid_salt,
-            auth_data.iterations
+            client_first=client_first,
+            salt=invalid_salt,
+            iterations=auth_data.iterations
         )
 
 
@@ -211,31 +211,31 @@ def test_server_first_message_invalid_iterations(client_first, auth_data,
     """Test ServerFirstMessage with invalid iteration values."""
     with pytest.raises(RuntimeError):
         truenas_pyscram.ServerFirstMessage(
-            client_first,
-            auth_data.salt,
-            invalid_iterations
+            client_first=client_first,
+            salt=auth_data.salt,
+            iterations=invalid_iterations
         )
 
 
 def test_server_first_message_reproducible_with_same_client(auth_data):
     """Test that ServerFirstMessage is deterministic for same client nonce."""
     # Create two client messages with same parameters
-    client1 = truenas_pyscram.ClientFirstMessage("testuser")
-    client2 = truenas_pyscram.ClientFirstMessage("testuser")
+    client1 = truenas_pyscram.ClientFirstMessage(username="testuser")
+    client2 = truenas_pyscram.ClientFirstMessage(username="testuser")
 
     # They should have different nonces (random generation)
     assert bytes(client1.nonce) != bytes(client2.nonce)
 
     # Server first messages should be different due to different client nonces
     msg1 = truenas_pyscram.ServerFirstMessage(
-        client1,
-        auth_data.salt,
-        auth_data.iterations
+        client_first=client1,
+        salt=auth_data.salt,
+        iterations=auth_data.iterations
     )
     msg2 = truenas_pyscram.ServerFirstMessage(
-        client2,
-        auth_data.salt,
-        auth_data.iterations
+        client_first=client2,
+        salt=auth_data.salt,
+        iterations=auth_data.iterations
     )
 
     assert str(msg1) != str(msg2)
@@ -248,9 +248,9 @@ def test_server_first_message_unique_server_nonces(client_first, auth_data):
     messages = []
     for _ in range(5):
         msg = truenas_pyscram.ServerFirstMessage(
-            client_first,
-            auth_data.salt,
-            auth_data.iterations
+            client_first=client_first,
+            salt=auth_data.salt,
+            iterations=auth_data.iterations
         )
         messages.append(msg)
 
@@ -267,12 +267,12 @@ def test_server_first_message_unique_server_nonces(client_first, auth_data):
 def test_server_first_message_with_different_clients(auth_data, username,
                                                      api_key_id):
     """Test ServerFirstMessage with different client configurations."""
-    client = truenas_pyscram.ClientFirstMessage(username,
+    client = truenas_pyscram.ClientFirstMessage(username=username,
                                                 api_key_id=api_key_id)
     msg = truenas_pyscram.ServerFirstMessage(
-        client,
-        auth_data.salt,
-        auth_data.iterations
+        client_first=client,
+        salt=auth_data.salt,
+        iterations=auth_data.iterations
     )
 
     # Should create valid message regardless of client configuration

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -13,33 +13,35 @@ def auth_data():
 @pytest.fixture
 def client_first():
     """Generate a client first message for testing."""
-    return truenas_pyscram.ClientFirstMessage("testuser")
+    return truenas_pyscram.ClientFirstMessage(username="testuser")
 
 
 @pytest.fixture
 def server_first(client_first, auth_data):
     """Generate a server first message for testing."""
-    return truenas_pyscram.ServerFirstMessage(client_first, auth_data.salt,
-                                              auth_data.iterations)
+    return truenas_pyscram.ServerFirstMessage(client_first=client_first,
+                                              salt=auth_data.salt,
+                                              iterations=auth_data.iterations)
 
 
 @pytest.fixture
 def client_final(client_first, server_first, auth_data):
     """Generate a client final message for testing."""
-    return truenas_pyscram.ClientFinalMessage(client_first, server_first,
-                                              auth_data.client_key,
-                                              auth_data.stored_key)
+    return truenas_pyscram.ClientFinalMessage(client_first=client_first,
+                                              server_first=server_first,
+                                              client_key=auth_data.client_key,
+                                              stored_key=auth_data.stored_key)
 
 
 @pytest.fixture
 def server_final(client_first, server_first, client_final, auth_data):
     """Generate a server final message for testing."""
     return truenas_pyscram.ServerFinalMessage(
-        client_first,
-        server_first,
-        client_final,
-        auth_data.stored_key,
-        auth_data.server_key
+        client_first=client_first,
+        server_first=server_first,
+        client_final=client_final,
+        stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key
     )
 
 
@@ -48,7 +50,8 @@ def test_verify_client_final_message_success(client_first, server_first,
     """Test successful client final message verification."""
     # Should not raise an exception
     truenas_pyscram.verify_client_final_message(
-        client_first, server_first, client_final, auth_data.stored_key)
+        client_first=client_first, server_first=server_first,
+        client_final=client_final, stored_key=auth_data.stored_key)
 
 
 def test_verify_server_signature_success(client_first, server_first,
@@ -56,8 +59,9 @@ def test_verify_server_signature_success(client_first, server_first,
     """Test successful server signature verification."""
     # Should not raise an exception
     truenas_pyscram.verify_server_signature(
-        client_first, server_first, client_final, server_final,
-        auth_data.server_key)
+        client_first=client_first, server_first=server_first,
+        client_final=client_final, server_final=server_final,
+        server_key=auth_data.server_key)
 
 
 def test_verify_client_final_message_with_wrong_key(client_first, server_first,
@@ -67,8 +71,8 @@ def test_verify_client_final_message_with_wrong_key(client_first, server_first,
 
     with pytest.raises(truenas_pyscram.ScramError, match="SCRAM_E_AUTH_FAILED"):
         truenas_pyscram.verify_client_final_message(
-            client_first, server_first, client_final,
-            wrong_auth_data.stored_key)
+            client_first=client_first, server_first=server_first,
+            client_final=client_final, stored_key=wrong_auth_data.stored_key)
 
 
 def test_verify_server_signature_with_wrong_key(client_first, server_first,
@@ -78,8 +82,9 @@ def test_verify_server_signature_with_wrong_key(client_first, server_first,
 
     with pytest.raises(truenas_pyscram.ScramError, match="SCRAM_E_AUTH_FAILED"):
         truenas_pyscram.verify_server_signature(
-            client_first, server_first, client_final, server_final,
-            wrong_auth_data.server_key)
+            client_first=client_first, server_first=server_first,
+            client_final=client_final, server_final=server_final,
+            server_key=wrong_auth_data.server_key)
 
 
 @pytest.mark.parametrize("invalid_param,param_name,expected_error", [
@@ -97,7 +102,8 @@ def test_verify_client_final_message_invalid_client_first(server_first,
     """Test client final message verification with invalid client_first."""
     with pytest.raises(TypeError, match=expected_error):
         truenas_pyscram.verify_client_final_message(
-            invalid_param, server_first, client_final, auth_data.stored_key)
+            client_first=invalid_param, server_first=server_first,
+            client_final=client_final, stored_key=auth_data.stored_key)
 
 
 @pytest.mark.parametrize("invalid_param,param_name,expected_error", [
@@ -115,7 +121,8 @@ def test_verify_client_final_message_invalid_server_first(client_first,
     """Test client final message verification with invalid server_first."""
     with pytest.raises(TypeError, match=expected_error):
         truenas_pyscram.verify_client_final_message(
-            client_first, invalid_param, client_final, auth_data.stored_key)
+            client_first=client_first, server_first=invalid_param,
+            client_final=client_final, stored_key=auth_data.stored_key)
 
 
 @pytest.mark.parametrize("invalid_param,param_name,expected_error", [
@@ -133,7 +140,8 @@ def test_verify_client_final_message_invalid_client_final(client_first,
     """Test client final message verification with invalid client_final."""
     with pytest.raises(TypeError, match=expected_error):
         truenas_pyscram.verify_client_final_message(
-            client_first, server_first, invalid_param, auth_data.stored_key)
+            client_first=client_first, server_first=server_first,
+            client_final=invalid_param, stored_key=auth_data.stored_key)
 
 
 @pytest.mark.parametrize("invalid_param,param_name,expected_error", [
@@ -151,7 +159,8 @@ def test_verify_client_final_message_invalid_stored_key(client_first,
     """Test client final message verification with invalid stored_key."""
     with pytest.raises(TypeError, match=expected_error):
         truenas_pyscram.verify_client_final_message(
-            client_first, server_first, client_final, invalid_param)
+            client_first=client_first, server_first=server_first,
+            client_final=client_final, stored_key=invalid_param)
 
 
 @pytest.mark.parametrize("invalid_param,param_name,expected_error", [
@@ -170,8 +179,9 @@ def test_verify_server_signature_invalid_client_first(server_first,
     """Test server signature verification with invalid client_first."""
     with pytest.raises(TypeError, match=expected_error):
         truenas_pyscram.verify_server_signature(
-            invalid_param, server_first, client_final, server_final,
-            auth_data.server_key)
+            client_first=invalid_param, server_first=server_first,
+            client_final=client_final, server_final=server_final,
+            server_key=auth_data.server_key)
 
 
 @pytest.mark.parametrize("invalid_param,param_name,expected_error", [
@@ -190,8 +200,9 @@ def test_verify_server_signature_invalid_server_first(client_first,
     """Test server signature verification with invalid server_first."""
     with pytest.raises(TypeError, match=expected_error):
         truenas_pyscram.verify_server_signature(
-            client_first, invalid_param, client_final, server_final,
-            auth_data.server_key)
+            client_first=client_first, server_first=invalid_param,
+            client_final=client_final, server_final=server_final,
+            server_key=auth_data.server_key)
 
 
 @pytest.mark.parametrize("invalid_param,param_name,expected_error", [
@@ -210,8 +221,9 @@ def test_verify_server_signature_invalid_client_final(client_first,
     """Test server signature verification with invalid client_final."""
     with pytest.raises(TypeError, match=expected_error):
         truenas_pyscram.verify_server_signature(
-            client_first, server_first, invalid_param, server_final,
-            auth_data.server_key)
+            client_first=client_first, server_first=server_first,
+            client_final=invalid_param, server_final=server_final,
+            server_key=auth_data.server_key)
 
 
 @pytest.mark.parametrize("invalid_param,param_name,expected_error", [
@@ -230,8 +242,9 @@ def test_verify_server_signature_invalid_server_final(client_first,
     """Test server signature verification with invalid server_final."""
     with pytest.raises(TypeError, match=expected_error):
         truenas_pyscram.verify_server_signature(
-            client_first, server_first, client_final, invalid_param,
-            auth_data.server_key)
+            client_first=client_first, server_first=server_first,
+            client_final=client_final, server_final=invalid_param,
+            server_key=auth_data.server_key)
 
 
 @pytest.mark.parametrize("invalid_param,param_name,expected_error", [
@@ -250,56 +263,67 @@ def test_verify_server_signature_invalid_server_key(client_first,
     """Test server signature verification with invalid server_key."""
     with pytest.raises(TypeError, match=expected_error):
         truenas_pyscram.verify_server_signature(
-            client_first, server_first, client_final, server_final,
-            invalid_param)
+            client_first=client_first, server_first=server_first,
+            client_final=client_final, server_final=server_final,
+            server_key=invalid_param)
 
 
 def test_verification_functions_with_channel_binding(auth_data):
     """Test verification functions with channel binding."""
     # Create client with channel binding
     client_first = truenas_pyscram.ClientFirstMessage(
-        "testuser", gs2_header="p=tls-unique")
+        username="testuser", gs2_header="p=tls-unique")
     server_first = truenas_pyscram.ServerFirstMessage(
-        client_first, auth_data.salt, auth_data.iterations)
+        client_first=client_first, salt=auth_data.salt,
+        iterations=auth_data.iterations)
 
     # Create channel binding data
     channel_binding = truenas_pyscram.CryptoDatum(b"fake_channel_binding_data")
 
     client_final = truenas_pyscram.ClientFinalMessage(
-        client_first, server_first, auth_data.client_key,
-        auth_data.stored_key, channel_binding)
+        client_first=client_first, server_first=server_first,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key,
+        channel_binding=channel_binding)
     server_final = truenas_pyscram.ServerFinalMessage(
-        client_first, server_first, client_final,
-        auth_data.stored_key, auth_data.server_key)
+        client_first=client_first, server_first=server_first,
+        client_final=client_final, stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key)
 
     # Both verifications should succeed
     truenas_pyscram.verify_client_final_message(
-        client_first, server_first, client_final, auth_data.stored_key)
+        client_first=client_first, server_first=server_first,
+        client_final=client_final, stored_key=auth_data.stored_key)
     truenas_pyscram.verify_server_signature(
-        client_first, server_first, client_final, server_final,
-        auth_data.server_key)
+        client_first=client_first, server_first=server_first,
+        client_final=client_final, server_final=server_final,
+        server_key=auth_data.server_key)
 
 
 def test_full_scram_flow_with_verification(auth_data):
     """Test complete SCRAM flow with verification."""
     # Complete SCRAM flow
-    client_first = truenas_pyscram.ClientFirstMessage("testuser")
+    client_first = truenas_pyscram.ClientFirstMessage(username="testuser")
     server_first = truenas_pyscram.ServerFirstMessage(
-        client_first, auth_data.salt, auth_data.iterations)
+        client_first=client_first, salt=auth_data.salt,
+        iterations=auth_data.iterations)
     client_final = truenas_pyscram.ClientFinalMessage(
-        client_first, server_first, auth_data.client_key, auth_data.stored_key)
+        client_first=client_first, server_first=server_first,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key)
     server_final = truenas_pyscram.ServerFinalMessage(
-        client_first, server_first, client_final,
-        auth_data.stored_key, auth_data.server_key)
+        client_first=client_first, server_first=server_first,
+        client_final=client_final, stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key)
 
     # Server verifies client final message (server-side verification)
     truenas_pyscram.verify_client_final_message(
-        client_first, server_first, client_final, auth_data.stored_key)
+        client_first=client_first, server_first=server_first,
+        client_final=client_final, stored_key=auth_data.stored_key)
 
     # Client verifies server signature (client-side verification)
     truenas_pyscram.verify_server_signature(
-        client_first, server_first, client_final, server_final,
-        auth_data.server_key)
+        client_first=client_first, server_first=server_first,
+        client_final=client_final, server_final=server_final,
+        server_key=auth_data.server_key)
 
 
 @pytest.mark.parametrize("username,api_key_id", [
@@ -310,42 +334,52 @@ def test_full_scram_flow_with_verification(auth_data):
 def test_verification_with_parametrized_clients(auth_data, username,
                                                api_key_id):
     """Test verification functions with parametrized client configurations."""
-    client = truenas_pyscram.ClientFirstMessage(username,
+    client = truenas_pyscram.ClientFirstMessage(username=username,
                                                 api_key_id=api_key_id)
     server_first = truenas_pyscram.ServerFirstMessage(
-        client, auth_data.salt, auth_data.iterations)
+        client_first=client, salt=auth_data.salt,
+        iterations=auth_data.iterations)
     client_final = truenas_pyscram.ClientFinalMessage(
-        client, server_first, auth_data.client_key, auth_data.stored_key)
+        client_first=client, server_first=server_first,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key)
     server_final = truenas_pyscram.ServerFinalMessage(
-        client, server_first, client_final,
-        auth_data.stored_key, auth_data.server_key)
+        client_first=client, server_first=server_first,
+        client_final=client_final, stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key)
 
     # Both verifications should succeed regardless of client configuration
     truenas_pyscram.verify_client_final_message(
-        client, server_first, client_final, auth_data.stored_key)
+        client_first=client, server_first=server_first,
+        client_final=client_final, stored_key=auth_data.stored_key)
     truenas_pyscram.verify_server_signature(
-        client, server_first, client_final, server_final,
-        auth_data.server_key)
+        client_first=client, server_first=server_first,
+        client_final=client_final, server_final=server_final,
+        server_key=auth_data.server_key)
 
 
 def test_verification_functions_return_none():
     """Test that verification functions return None on success."""
     auth_data = truenas_pyscram.generate_scram_auth_data()
-    client_first = truenas_pyscram.ClientFirstMessage("testuser")
+    client_first = truenas_pyscram.ClientFirstMessage(username="testuser")
     server_first = truenas_pyscram.ServerFirstMessage(
-        client_first, auth_data.salt, auth_data.iterations)
+        client_first=client_first, salt=auth_data.salt,
+        iterations=auth_data.iterations)
     client_final = truenas_pyscram.ClientFinalMessage(
-        client_first, server_first, auth_data.client_key, auth_data.stored_key)
+        client_first=client_first, server_first=server_first,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key)
     server_final = truenas_pyscram.ServerFinalMessage(
-        client_first, server_first, client_final,
-        auth_data.stored_key, auth_data.server_key)
+        client_first=client_first, server_first=server_first,
+        client_final=client_final, stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key)
 
     # Both functions should return None on success
     result1 = truenas_pyscram.verify_client_final_message(
-        client_first, server_first, client_final, auth_data.stored_key)
+        client_first=client_first, server_first=server_first,
+        client_final=client_final, stored_key=auth_data.stored_key)
     result2 = truenas_pyscram.verify_server_signature(
-        client_first, server_first, client_final, server_final,
-        auth_data.server_key)
+        client_first=client_first, server_first=server_first,
+        client_final=client_final, server_final=server_final,
+        server_key=auth_data.server_key)
 
     assert result1 is None
     assert result2 is None
@@ -354,18 +388,21 @@ def test_verification_functions_return_none():
 def test_scram_error_properties():
     """Test that ScramError has correct properties."""
     auth_data = truenas_pyscram.generate_scram_auth_data()
-    client_first = truenas_pyscram.ClientFirstMessage("testuser")
+    client_first = truenas_pyscram.ClientFirstMessage(username="testuser")
     server_first = truenas_pyscram.ServerFirstMessage(
-        client_first, auth_data.salt, auth_data.iterations)
+        client_first=client_first, salt=auth_data.salt,
+        iterations=auth_data.iterations)
     client_final = truenas_pyscram.ClientFinalMessage(
-        client_first, server_first, auth_data.client_key, auth_data.stored_key)
+        client_first=client_first, server_first=server_first,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key)
 
     # Use wrong key to trigger SCRAM authentication failure
     wrong_auth = truenas_pyscram.generate_scram_auth_data()
 
     with pytest.raises(truenas_pyscram.ScramError) as exc_info:
         truenas_pyscram.verify_client_final_message(
-            client_first, server_first, client_final, wrong_auth.stored_key)
+            client_first=client_first, server_first=server_first,
+            client_final=client_final, stored_key=wrong_auth.stored_key)
 
     # Check that the exception has the expected attributes
     exc = exc_info.value


### PR DESCRIPTION
This commit adds the ability to pass an rfc_string kwarg to the SCRAM communication objects in order to construct the relevant message types from server responses. This is important for testing SCRAM responses from pam_truenas.