### PR TITLE
Harden scram handling and follow RFC more closely (#9)

### DIFF
--- a/src/scram/scram_attr_parse.c
+++ b/src/scram/scram_attr_parse.c
@@ -164,6 +164,22 @@ scram_resp_t scram_parse_principal(char *str_in,
 		principal_out->api_key_id = api_key_id;
 	}
 
+	/*
+	 * RFC 5802 Section 5.1 carries ',' and '=' in a SCRAM username as the
+	 * escapes "=2C" and "=3D", and requires the server to fail the
+	 * authentication when a '=' is not part of such an escape. TrueNAS usernames
+	 * cannot contain ',' or '=' in the first place, so rather than decode the
+	 * escapes we reject the whole class -- both raw characters and any
+	 * "=2C"/"=3D" sequence -- which keeps the username unambiguous and fails
+	 * closed. (A raw ',' cannot reach here anyway; it terminates the attribute
+	 * during tokenization.)
+	 */
+	if (strpbrk(str_in, "=,") != NULL) {
+		scram_set_error(error, "%s: username must not contain '=' or ','",
+				str_in);
+		return SCRAM_E_FORMAT_ERROR;
+	}
+
 	// We need to SASLPREP the username str and verify that it
 	// matches the raw str
 	ret = scram_saslprep(str_in,

--- a/src/scram/scram_client_final.c
+++ b/src/scram/scram_client_final.c
@@ -525,6 +525,51 @@ cleanup_resources:
 	return ret;
 }
 
+/*
+ * Validate the exact gs2-header echoed in the client's c= attribute. A valid
+ * header is the bare gs2-cbind-flag ("n" or "y"), or "p=<cb-name>" naming a
+ * channel-binding type this server supports.
+ *
+ * SCRAM_CB_TLS_SERVER_END_POINT (RFC 5929) is the only type this library
+ * computes; extend this check if more are added. Rejecting anything else closes
+ * two gaps the ClientProof alone does not cover (the proof binds whatever the
+ * client committed to, but says nothing about whether the server accepts it):
+ *   - an "a=" authzid (RFC 5801 Section 4 / RFC 5802 Section 7) -- this library
+ *     does not implement authzid, so a header carrying one must fail rather than
+ *     be silently ignored; and
+ *   - a "p" naming an unsupported channel-binding type (RFC 5802 Section 6: "if
+ *     the channel binding flag was 'p' and the server does not support the
+ *     indicated channel binding type, then the server MUST fail
+ *     authentication").
+ */
+static scram_resp_t validate_gs2_cbind_header(const char *gs2_header, char flag,
+					      scram_error_t *error)
+{
+	if (!gs2_header || !gs2_header[0]) {
+		/* Absent/empty header is the default "n"; nothing more to check. */
+		return SCRAM_E_SUCCESS;
+	}
+
+	if (flag == GS2_FLAG_CB_USED[0]) {
+		/* Require exactly "p=<supported-cb-name>" with no trailing authzid. */
+		if (gs2_header[1] != '=' ||
+		    strcmp(gs2_header + 2, SCRAM_CB_TLS_SERVER_END_POINT) != 0) {
+			scram_set_error(error, "unsupported channel-binding type or "
+					"unexpected authzid in gs2 'p' header");
+			return SCRAM_E_AUTH_FAILED;
+		}
+		return SCRAM_E_SUCCESS;
+	}
+
+	/* "n" / "y": the header must be just the one-character flag (no authzid). */
+	if (gs2_header[1] != '\0') {
+		scram_set_error(error, "unexpected authzid or trailing data in gs2 "
+				"channel-binding header");
+		return SCRAM_E_AUTH_FAILED;
+	}
+	return SCRAM_E_SUCCESS;
+}
+
 static scram_resp_t enforce_channel_binding_policy(const scram_client_final_t *cfinal,
 						   const crypto_datum_t *expected_channel_binding,
 						   bool require_channel_binding,
@@ -542,22 +587,57 @@ static scram_resp_t enforce_channel_binding_policy(const scram_client_final_t *c
 	 * cbind-data equals THIS server's binding -- which is what detects a
 	 * TLS-terminating MITM relaying an otherwise-valid proof.
 	 *
-	 * Policy applies only when the server supports channel binding (an expected
-	 * value was supplied) or requires it; otherwise this is a plain (non-PLUS)
-	 * verification and the binding is ignored for backward compatibility.
-	 */
-	if (!server_supports_cb && !require_channel_binding) {
-		return SCRAM_E_SUCCESS;
-	}
-
-	/*
 	 * A missing/empty gs2 header means "no channel binding" -- the same as an
-	 * explicit "n" and the default applied during serialization. Treat it as
-	 * 'n' so the common no-CB client is handled consistently (rejected only
-	 * when channel binding is required), not as an invalid flag.
+	 * explicit "n" and the default applied during serialization. Treat it as 'n'
+	 * so the common no-CB client is handled consistently, not as an invalid flag.
 	 */
 	flag = (cfinal->gs2_header && cfinal->gs2_header[0]) ?
 	       cfinal->gs2_header[0] : GS2_FLAG_NO_CB_SUPPORT[0];
+
+	/*
+	 * RFC 5802 Section 5.1: the gs2-cbind-flag is "n", "y", or "p"; "otherwise,
+	 * the message is invalid and authentication MUST fail." Check this (and the
+	 * full header form) before the backward-compatible shortcut below so a
+	 * malformed flag or an unsupported binding type is never accepted as a no-op
+	 * on the plain (non-PLUS) path.
+	 */
+	if (flag != GS2_FLAG_NO_CB_SUPPORT[0] &&
+	    flag != GS2_FLAG_CB_SUPPORT_NOT_USED[0] &&
+	    flag != GS2_FLAG_CB_USED[0]) {
+		scram_set_error(error, "invalid gs2 channel-binding flag");
+		return SCRAM_E_PARSE_ERROR;
+	}
+
+	ret = validate_gs2_cbind_header(cfinal->gs2_header, flag, error);
+	if (ret != SCRAM_E_SUCCESS) {
+		return ret;
+	}
+
+	/*
+	 * A server that requires channel binding must supply the binding to validate
+	 * against (RFC 5802 Section 6: the server validates c= against its own
+	 * binding). require + no binding is a caller misconfiguration we cannot
+	 * honor, so reject it explicitly rather than silently treating the request as
+	 * unbound.
+	 */
+	if (require_channel_binding && !server_supports_cb) {
+		scram_set_error(error, "channel binding required but no server "
+				"channel binding is configured");
+		return SCRAM_E_INVALID_REQUEST;
+	}
+
+	/*
+	 * Plain (non-PLUS) verification: when the server neither supplied a binding
+	 * nor requires one, an "n"/"y" client carries no cbind-data to validate, so
+	 * accept it for backward compatibility. A "p" client, however, committed
+	 * cbind-data that RFC 5802 Section 6 requires the server to validate against
+	 * its own binding -- impossible without one -- so it must not take this
+	 * shortcut: it falls through to the "p" branch and fails below.
+	 */
+	if (!server_supports_cb && !require_channel_binding &&
+	    flag != GS2_FLAG_CB_USED[0]) {
+		return SCRAM_E_SUCCESS;
+	}
 
 	if (flag == GS2_FLAG_CB_USED[0]) {
 		/* "p": client used channel binding -> it must match ours */
@@ -584,28 +664,20 @@ static scram_resp_t enforce_channel_binding_policy(const scram_client_final_t *c
 	} else if (flag == GS2_FLAG_CB_SUPPORT_NOT_USED[0]) {
 		/*
 		 * "y": client supports channel binding but believed the server did
-		 * not. Since this server does, it is a downgrade and MUST fail
-		 * (RFC 5802 Section 6).
+		 * not. We only reach here when the server does support it (the require
+		 * guard above already rejected require + no binding), so it is a
+		 * downgrade and MUST fail (RFC 5802 Section 6).
 		 */
 		scram_set_error(error, "channel-binding downgrade detected "
 				"(gs2 'y' flag)");
 		return SCRAM_E_AUTH_FAILED;
-	} else if (flag == GS2_FLAG_NO_CB_SUPPORT[0]) {
-		/* "n": client does not support channel binding */
+	} else {
+		/* "n": client does not support channel binding (flag validated above) */
 		if (require_channel_binding) {
 			scram_set_error(error, "channel binding required but the "
 					"client did not use it");
 			return SCRAM_E_AUTH_FAILED;
 		}
-	} else {
-		/*
-		 * Not n/y/p: the gs2-cbind-flag is outside the RFC 5802 grammar.
-		 * Unlike the branches above -- which reject *valid* flags on policy
-		 * grounds -- this is a malformed message, so report it as a parse
-		 * error rather than an auth failure.
-		 */
-		scram_set_error(error, "invalid gs2 channel-binding flag");
-		return SCRAM_E_PARSE_ERROR;
 	}
 
 	return SCRAM_E_SUCCESS;
@@ -632,6 +704,22 @@ scram_resp_t scram_verify_client_final_message_cb(const scram_client_first_t *cf
 	if (!cfirst || !sfirst || !cfinal || !SCRAM_DATUM_IS_VALID(stored_key)) {
 		scram_set_error(error, "invalid input parameters");
 		return SCRAM_E_INVALID_REQUEST;
+	}
+
+	/*
+	 * RFC 5802 Section 5.1: "The server MUST verify that the nonce sent by the
+	 * client in the second message is the same as the one sent by the server in
+	 * its first message." The ClientProof verified below also covers the nonce
+	 * (r= is part of the AuthMessage), but check it explicitly so a mismatch is
+	 * rejected here rather than surfacing only as a proof failure. The nonce is
+	 * public, so a plain comparison (not constant-time) is sufficient.
+	 */
+	if (!SCRAM_DATUM_IS_VALID(&cfinal->nonce) ||
+	    !SCRAM_DATUM_IS_VALID(&sfirst->nonce) ||
+	    cfinal->nonce.size != sfirst->nonce.size ||
+	    memcmp(cfinal->nonce.data, sfirst->nonce.data, sfirst->nonce.size) != 0) {
+		scram_set_error(error, "client nonce does not match server nonce");
+		return SCRAM_E_AUTH_FAILED;
 	}
 
 	/* Create client-first-message-bare for AuthMessage */

--- a/src/scram/scram_client_first.c
+++ b/src/scram/scram_client_first.c
@@ -287,6 +287,18 @@ scram_resp_t scram_create_client_first_message(const char *username,
 		return SCRAM_E_INVALID_REQUEST;
 	}
 
+	/*
+	 * Reject ',' and '=' in the username up front. The SCRAM message is
+	 * comma-separated and uses '=' for the "=2C"/"=3D" username escapes (RFC 5802
+	 * Section 5.1) that this library does not emit. Mirroring the parser's check
+	 * here keeps the library from ever building a username its own verifier would
+	 * reject.
+	 */
+	if (strpbrk(username, "=,") != NULL) {
+		scram_set_error(error, "username must not contain '=' or ','");
+		return SCRAM_E_FORMAT_ERROR;
+	}
+
 	msg = calloc(1, sizeof(*msg));
 	if (!msg) {
 		scram_set_error(error, "calloc() failed");

--- a/src/scram/truenas_scram.h
+++ b/src/scram/truenas_scram.h
@@ -368,16 +368,34 @@ scram_resp_t scram_verify_client_final_message(const scram_client_first_t *cfirs
  * @brief Verify a SCRAM client-final-message with channel binding (SCRAM-PLUS).
  *
  * Like scram_verify_client_final_message(), but additionally enforces channel
- * binding per RFC 5802 6 / RFC 5801. When @p expected_channel_binding is non-NULL
- * the server is treated as channel-binding-capable: a "p" gs2 flag's cbind-data
- * must equal @p expected_channel_binding (constant-time), a "y" flag is rejected
- * as a downgrade, and a "n" flag is rejected only when @p require_channel_binding
- * is true. With a NULL expected binding and require=false this behaves exactly
- * like the plain verification.
+ * binding per RFC 5802 Section 6 / RFC 5801. The nonce and ClientProof are
+ * verified exactly as in the plain function; the channel-binding policy is then
+ * applied as follows.
+ *
+ * @p expected_channel_binding being non-NULL is how the caller declares that
+ * *this server* supports channel binding. When it is supplied:
+ *   - a "p" gs2 flag's cbind-data must equal @p expected_channel_binding
+ *     (constant-time), and its cb-name must be the supported type
+ *     (SCRAM_CB_TLS_SERVER_END_POINT, RFC 5929); otherwise authentication fails;
+ *   - a "y" gs2 flag is rejected as a downgrade (RFC 5802 Section 6); and
+ *   - a "n" gs2 flag is rejected only when @p require_channel_binding is true.
+ * With a NULL expected binding and require=false this behaves like the plain
+ * verification (a "p" client is still rejected, since the server has nothing to
+ * validate its c= against).
+ *
+ * IMPORTANT (contract): a server that is channel-binding-capable (i.e. running
+ * over TLS) MUST pass its @p expected_channel_binding on every call; omitting it
+ * disables "y"-downgrade detection for that exchange. Passing
+ * @p require_channel_binding = true with a NULL @p expected_channel_binding is a
+ * caller error and is rejected with SCRAM_E_INVALID_REQUEST (there would be no
+ * binding to enforce). An authzid in the client's gs2-header is not supported
+ * and causes authentication to fail rather than being ignored.
  *
  * @param[in] expected_channel_binding - this server's channel binding value
- *            (e.g. the RFC 5929 tls-server-end-point hash), or NULL.
- * @param[in] require_channel_binding - reject clients that do not use binding.
+ *            (the RFC 5929 tls-server-end-point hash), or NULL if the server
+ *            does not support channel binding.
+ * @param[in] require_channel_binding - reject clients that do not use binding;
+ *            requires a non-NULL @p expected_channel_binding.
  */
 scram_resp_t scram_verify_client_final_message_cb(const scram_client_first_t *cfirst,
 					      const scram_server_first_t *sfirst,

--- a/tests/test_client_first.py
+++ b/tests/test_client_first.py
@@ -289,3 +289,14 @@ def test_client_first_channel_binding_type_conflicts_rfc_string():
         truenas_pyscram.ClientFirstMessage(
             rfc_string=rfc,
             channel_binding_type=truenas_pyscram.CB_TLS_SERVER_END_POINT)
+
+
+@pytest.mark.parametrize("bad_username", ["user=name", "user,name", "a=2Cb"])
+def test_client_first_rejects_reserved_username_chars(bad_username):
+    """RFC 5802 Section 5.1 reserves ',' and '=' in the SCRAM username (carried
+    on the wire as =2C/=3D). TrueNAS usernames never contain them, so the library
+    rejects the whole class -- raw characters and =2C/=3D escapes alike -- rather
+    than emitting an ambiguous message."""
+    with pytest.raises(truenas_pyscram.ScramError,
+                       match="username must not contain"):
+        truenas_pyscram.ClientFirstMessage(username=bad_username)

--- a/tests/test_rfc_parsing.py
+++ b/tests/test_rfc_parsing.py
@@ -353,3 +353,12 @@ def test_username_api_key_combinations(username, api_key_id):
     assert str(msg1) == str(msg2)
     assert msg2.username == username
     assert msg2.api_key_id == api_key_id
+
+
+def test_parse_rejects_equals_in_username():
+    """RFC 5802 Section 5.1: a server MUST fail on a username containing a '='
+    that is not a valid =2C/=3D escape. This library rejects '=' in the parsed
+    username outright (a raw ',' cannot appear: it terminates the attribute)."""
+    bad_rfc = "n,,n=user=name,r=" + "A" * 43
+    with pytest.raises(scram.ScramError, match="username must not contain"):
+        scram.ClientFirstMessage(rfc_string=bad_rfc)

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -270,9 +270,10 @@ def test_verify_server_signature_invalid_server_key(client_first,
 
 def test_verification_functions_with_channel_binding(auth_data):
     """Test verification functions with channel binding."""
-    # Create client with channel binding
+    # Create client with channel binding (the only supported cb-name)
     client_first = truenas_pyscram.ClientFirstMessage(
-        username="testuser", gs2_header="p=x-test-binding")
+        username="testuser",
+        channel_binding_type=truenas_pyscram.CB_TLS_SERVER_END_POINT)
     server_first = truenas_pyscram.ServerFirstMessage(
         client_first=client_first, salt=auth_data.salt,
         iterations=auth_data.iterations)
@@ -289,10 +290,12 @@ def test_verification_functions_with_channel_binding(auth_data):
         client_final=client_final, stored_key=auth_data.stored_key,
         server_key=auth_data.server_key)
 
-    # Both verifications should succeed
+    # Both verifications should succeed (server supplies the matching binding;
+    # a "p" client is rejected without one -- see the dedicated test below)
     truenas_pyscram.verify_client_final_message(
         client_first=client_first, server_first=server_first,
-        client_final=client_final, stored_key=auth_data.stored_key)
+        client_final=client_final, stored_key=auth_data.stored_key,
+        channel_binding=channel_binding)
     truenas_pyscram.verify_server_signature(
         client_first=client_first, server_first=server_first,
         client_final=client_final, server_final=server_final,
@@ -514,3 +517,104 @@ def test_verify_client_final_y_flag_downgrade_rejected(auth_data):
             client_first=client_first, server_first=server_first,
             client_final=client_final, stored_key=auth_data.stored_key,
             channel_binding=truenas_pyscram.CryptoDatum(b"A" * 32))
+
+
+def test_verify_client_final_p_flag_no_server_binding_rejected(auth_data):
+    """A 'p' client must fail when the server has no binding to validate its c=
+    against, even when channel binding is not required (RFC 5802 Section 6: the
+    server MUST always validate the client's c=)."""
+    binding = truenas_pyscram.compute_tls_server_end_point(_self_signed_cert_der())
+    client_first, server_first, client_final = _channel_bound_client(
+        auth_data, binding)
+
+    # No server binding supplied, require_channel_binding defaults to False.
+    with pytest.raises(truenas_pyscram.ScramError, match="no server channel binding"):
+        truenas_pyscram.verify_client_final_message(
+            client_first=client_first, server_first=server_first,
+            client_final=client_final, stored_key=auth_data.stored_key)
+
+
+def test_verify_client_final_p_flag_unsupported_cb_name_rejected(auth_data):
+    """RFC 5802 Section 6: a 'p' client naming a channel-binding type the server
+    does not support MUST fail, even when the binding *value* matches. tls-unique
+    is a real RFC 5929 type, but this library only supports tls-server-end-point."""
+    binding = truenas_pyscram.CryptoDatum(b"A" * 32)
+    client_first = truenas_pyscram.ClientFirstMessage(
+        username="testuser", gs2_header="p=tls-unique")
+    server_first = truenas_pyscram.ServerFirstMessage(
+        client_first=client_first, salt=auth_data.salt,
+        iterations=auth_data.iterations)
+    client_final = truenas_pyscram.ClientFinalMessage(
+        client_first=client_first, server_first=server_first,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key,
+        channel_binding=binding)
+
+    with pytest.raises(truenas_pyscram.ScramError,
+                       match="unsupported channel-binding type"):
+        truenas_pyscram.verify_client_final_message(
+            client_first=client_first, server_first=server_first,
+            client_final=client_final, stored_key=auth_data.stored_key,
+            channel_binding=binding, require_channel_binding=True)
+
+
+def test_verify_client_final_require_without_server_binding_rejected(auth_data):
+    """require_channel_binding with no server binding to enforce is a caller
+    misconfiguration and must be rejected, not silently treated as unbound
+    (RFC 5802 Section 6: the server validates c= against its own binding)."""
+    client_first = truenas_pyscram.ClientFirstMessage(username="testuser")
+    server_first = truenas_pyscram.ServerFirstMessage(
+        client_first=client_first, salt=auth_data.salt,
+        iterations=auth_data.iterations)
+    client_final = truenas_pyscram.ClientFinalMessage(
+        client_first=client_first, server_first=server_first,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key)
+
+    with pytest.raises(truenas_pyscram.ScramError,
+                       match="no server channel binding is configured"):
+        truenas_pyscram.verify_client_final_message(
+            client_first=client_first, server_first=server_first,
+            client_final=client_final, stored_key=auth_data.stored_key,
+            require_channel_binding=True)
+
+
+def test_verify_client_final_invalid_gs2_flag_rejected(auth_data):
+    """RFC 5802 Section 5.1: the gs2-cbind-flag must be n/y/p; anything else is a
+    malformed message and authentication MUST fail -- including on the plain,
+    non-PLUS verification path where no binding is supplied or required."""
+    client_first = truenas_pyscram.ClientFirstMessage(
+        username="testuser", gs2_header="z")
+    server_first = truenas_pyscram.ServerFirstMessage(
+        client_first=client_first, salt=auth_data.salt,
+        iterations=auth_data.iterations)
+    client_final = truenas_pyscram.ClientFinalMessage(
+        client_first=client_first, server_first=server_first,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key)
+
+    with pytest.raises(truenas_pyscram.ScramError,
+                       match="invalid gs2 channel-binding flag"):
+        truenas_pyscram.verify_client_final_message(
+            client_first=client_first, server_first=server_first,
+            client_final=client_final, stored_key=auth_data.stored_key)
+
+
+def test_verify_client_final_nonce_mismatch_rejected(auth_data):
+    """RFC 5802 Section 5.1: "the server MUST verify that the nonce sent by the
+    client ... is the same as the one sent by the server." A client-final bound
+    to a different server-first (different server nonce) must be rejected."""
+    client_first = truenas_pyscram.ClientFirstMessage(username="testuser")
+    server_first_a = truenas_pyscram.ServerFirstMessage(
+        client_first=client_first, salt=auth_data.salt,
+        iterations=auth_data.iterations)
+    server_first_b = truenas_pyscram.ServerFirstMessage(
+        client_first=client_first, salt=auth_data.salt,
+        iterations=auth_data.iterations)
+    client_final = truenas_pyscram.ClientFinalMessage(
+        client_first=client_first, server_first=server_first_a,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key)
+
+    # Verify against server_first_b, whose server nonce differs from A's.
+    with pytest.raises(truenas_pyscram.ScramError,
+                       match="client nonce does not match server nonce"):
+        truenas_pyscram.verify_client_final_message(
+            client_first=client_first, server_first=server_first_b,
+            client_final=client_final, stored_key=auth_data.stored_key)


### PR DESCRIPTION
* Reject client requests with authzid. We don't handle these server-side and should not present to client that we do.

* Properly handle a variety of edge cases involving a mixture of client / server channel binding support negotiation situations per RFC guidelines (to protect against downgrades).