### PR TITLE
NAS-141930 / 26.0.0-BETA.3 / Fix CryptoDatum UAF risk (by anodos325)

### DIFF
--- a/src/pyscram/crypto_datum.c
+++ b/src/pyscram/crypto_datum.c
@@ -12,6 +12,17 @@ py_crypto_datum_init(py_crypto_datum_t *self, PyObject *args, PyObject *kwds)
 	scram_error_t error = {0};
 	scram_resp_t ret;
 
+	/*
+	 * A CryptoDatum wraps a single secret value and is immutable once
+	 * initialized; re-initialization is rejected.
+	 */
+	if (SCRAM_DATUM_IS_VALID(&self->datum)) {
+		PyErr_SetString(PyExc_RuntimeError,
+				"CryptoDatum is immutable and cannot be "
+				"re-initialized");
+		return -1;
+	}
+
 	if (!PyArg_ParseTuple(args, "y#", &data, &data_len)) {
 		return -1;
 	}
@@ -35,7 +46,18 @@ py_crypto_datum_init(py_crypto_datum_t *self, PyObject *args, PyObject *kwds)
 static void
 py_crypto_datum_dealloc(py_crypto_datum_t *self)
 {
-	crypto_datum_clear(&self->datum, true);
+	/*
+	 * Free on the data pointer directly rather than via crypto_datum_clear():
+	 * clear() zeroes the buffer and sets size to 0 while keeping it allocated,
+	 * and crypto_datum_clear() skips the free() when size is 0.
+	 */
+	if (self->datum.data) {
+		if (self->datum.size > 0) {
+			explicit_bzero(self->datum.data, self->datum.size);
+		}
+		free(self->datum.data);
+	}
+	explicit_bzero(&self->datum, sizeof(self->datum));
 	Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
@@ -155,22 +177,20 @@ py_crypto_datum_richcompare(py_crypto_datum_t *self, PyObject *other, int op)
 PyDoc_STRVAR(py_crypto_datum_clear__doc__,
 "clear() -> None\n"
 "-------------\n\n"
-"Clear and securely zero the cryptographic data.\n\n"
-"This method securely overwrites the underlying data with zeros\n"
-"and frees the allocated memory. After calling this method,\n"
-"the CryptoDatum object becomes empty and should not be used\n"
-"for cryptographic operations.\n\n"
-"The operation releases the Global Interpreter Lock (GIL)\n"
-"for better performance in multithreaded environments.\n"
+"Securely zero the cryptographic data in place.\n\n"
+"Overwrites the underlying buffer with zeros using explicit_bzero()\n"
+"and resets the length to zero. The buffer itself is released when the\n"
+"object is destroyed. After clear() the datum is empty and must not be\n"
+"used for cryptographic operations.\n"
 );
 
 static PyObject *
 py_crypto_datum_clear(py_crypto_datum_t *self, PyObject *Py_UNUSED(ignored))
 {
-	Py_BEGIN_ALLOW_THREADS
-	crypto_datum_clear(&self->datum, true);
-	Py_END_ALLOW_THREADS
-
+	if (self->datum.data && self->datum.size > 0) {
+		explicit_bzero(self->datum.data, self->datum.size);
+		self->datum.size = 0;
+	}
 	Py_RETURN_NONE;
 }
 

--- a/tests/test_nonce.py
+++ b/tests/test_nonce.py
@@ -1,5 +1,6 @@
 """Test nonce generation functionality."""
 
+import pytest
 import truenas_pyscram
 
 
@@ -89,3 +90,23 @@ def test_crypto_datum_clear():
     assert len(empty_datum) == 0
     # Both should be empty and equal
     assert len(nonce) == len(empty_datum)
+
+
+def test_crypto_datum_is_immutable():
+    """A CryptoDatum holding data cannot be re-initialized; the original
+    value is left intact."""
+    datum = truenas_pyscram.CryptoDatum(b"secret-key-material")
+    with pytest.raises(RuntimeError, match="immutable"):
+        datum.__init__(b"replacement")
+    assert bytes(datum) == b"secret-key-material"
+
+
+def test_memoryview_reads_zeros_after_clear():
+    """A memoryview taken before clear() stays valid and reads zeros:
+    clear() zeroizes the buffer in place and keeps it allocated until the
+    object is destroyed."""
+    datum = truenas_pyscram.CryptoDatum(b"A" * 32)
+    view = memoryview(datum)
+    assert bytes(view) == b"A" * 32
+    datum.clear()
+    assert bytes(view) == b"\x00" * 32


### PR DESCRIPTION
clear() freed the underlying buffer while a memoryview or a GIL-dropped C call could still hold a raw pointer into it. Reaching the freed heap requires holding a memoryview across clear(), which TrueNAS does not do -- it consumes these datums via bytes(cd), a transient copy released within the call -- so this is a latent hazard of the API surface, not a path exercised in practice.

Tie the buffer's lifetime to the object:
- clear() zeroizes in place and sets the length to 0 without freeing; the buffer is released only in dealloc. A memoryview taken before clear() now reads zeros instead of freed heap, and a concurrent clear() during verification can at worst zero bytes mid-read.
- dealloc frees on the data pointer directly, so the size-0 state left by clear() is still released.
- CryptoDatum is now immutable: a second __init__ raises rather than overwriting the buffer it already holds.

Drop the GIL release around clear(): it wrapped only a small explicit_bzero, where the release/reacquire costs more than the wipe.

Original PR: https://github.com/truenas/truenas_scram/pull/13
