### PR TITLE
NAS-141929 / 26.0.0-BETA.3 / Fix interpreter crash on message constructors with missing args (by anodos325)

### DIFF
--- a/src/pyscram/py_client_final.c
+++ b/src/pyscram/py_client_final.c
@@ -37,9 +37,11 @@ parse_client_final_params(PyObject *args, PyObject *kwds,
 		return -1;
 	}
 
-	if (!*rfc_string && !client_first_obj) {
+	if (!*rfc_string && (!client_first_obj || !server_first_obj ||
+			     !client_key_obj || !stored_key_obj)) {
 		PyErr_SetString(PyExc_ValueError,
-				"Must specify either rfc_string or message parameters");
+				"Must specify either rfc_string or all of client_first, "
+				"server_first, client_key and stored_key");
 		return -1;
 	}
 

--- a/src/pyscram/py_server_final.c
+++ b/src/pyscram/py_server_final.c
@@ -37,9 +37,12 @@ parse_server_final_params(PyObject *args, PyObject *kwds,
 		return -1;
 	}
 
-	if (!*rfc_string && !client_first_obj) {
+	if (!*rfc_string && (!client_first_obj || !server_first_obj ||
+			     !client_final_obj || !stored_key_obj ||
+			     !server_key_obj)) {
 		PyErr_SetString(PyExc_ValueError,
-				"Must specify either rfc_string or message parameters");
+				"Must specify either rfc_string or all of client_first, "
+				"server_first, client_final, stored_key and server_key");
 		return -1;
 	}
 

--- a/src/pyscram/py_server_first.c
+++ b/src/pyscram/py_server_first.c
@@ -30,9 +30,10 @@ py_server_first_init(py_server_first_t *self, PyObject *args, PyObject *kwds)
 		return -1;
 	}
 
-	if (!rfc_string && !client_first_obj) {
+	if (!rfc_string && (!client_first_obj || !salt_obj)) {
 		PyErr_SetString(PyExc_ValueError,
-				"Must specify either rfc_string or client_first parameter");
+				"Must specify either rfc_string or both client_first "
+				"and salt");
 		return -1;
 	}
 

--- a/tests/test_client_final.py
+++ b/tests/test_client_final.py
@@ -431,3 +431,17 @@ def test_client_final_n_flag_rejects_binding(client_first, server_first, auth_da
             client_key=auth_data.client_key,
             stored_key=auth_data.stored_key,
             channel_binding=truenas_pyscram.CryptoDatum(b"x" * 32))
+
+
+@pytest.mark.parametrize("omit", ["client_first", "server_first",
+                                  "client_key", "stored_key"])
+def test_client_final_requires_all_creation_args(client_first, server_first,
+                                                 auth_data, omit):
+    """Without rfc_string, client_first, server_first, client_key and
+    stored_key are all required; omitting any one raises ValueError."""
+    kwargs = dict(client_first=client_first, server_first=server_first,
+                  client_key=auth_data.client_key,
+                  stored_key=auth_data.stored_key)
+    del kwargs[omit]
+    with pytest.raises(ValueError, match="Must specify either rfc_string"):
+        truenas_pyscram.ClientFinalMessage(**kwargs)

--- a/tests/test_rfc_parsing.py
+++ b/tests/test_rfc_parsing.py
@@ -105,7 +105,7 @@ def test_server_first_parse_various_iterations(iterations):
 
 def test_server_first_no_params_error():
     """Test that ServerFirstMessage requires either client_first or rfc_string."""
-    with pytest.raises(ValueError, match="Must specify either rfc_string or client_first"):
+    with pytest.raises(ValueError, match="Must specify either rfc_string"):
         scram.ServerFirstMessage()
 
 
@@ -186,7 +186,7 @@ def test_client_final_parse_with_channel_binding(client_server_first_messages):
 
 def test_client_final_no_params_error():
     """Test that ClientFinalMessage requires parameters."""
-    with pytest.raises(ValueError, match="Must specify either rfc_string or message parameters"):
+    with pytest.raises(ValueError, match="Must specify either rfc_string"):
         scram.ClientFinalMessage()
 
 
@@ -245,7 +245,7 @@ def test_server_final_parse_basic(all_messages):
 
 def test_server_final_no_params_error():
     """Test that ServerFinalMessage requires parameters."""
-    with pytest.raises(ValueError, match="Must specify either rfc_string or message parameters"):
+    with pytest.raises(ValueError, match="Must specify either rfc_string"):
         scram.ServerFinalMessage()
 
 

--- a/tests/test_server_final.py
+++ b/tests/test_server_final.py
@@ -375,3 +375,17 @@ def test_server_final_message_parametrized_clients(auth_data, username,
     msg_str = str(msg)
     assert msg_str.startswith('v=')
     assert len(msg_str) > 3  # More than just "v="
+
+
+@pytest.mark.parametrize("omit", ["client_first", "server_first",
+                                  "client_final", "stored_key", "server_key"])
+def test_server_final_requires_all_creation_args(client_first, server_first,
+                                                 client_final, auth_data, omit):
+    """Without rfc_string, all five creation arguments are required;
+    omitting any one raises ValueError."""
+    kwargs = dict(client_first=client_first, server_first=server_first,
+                  client_final=client_final, stored_key=auth_data.stored_key,
+                  server_key=auth_data.server_key)
+    del kwargs[omit]
+    with pytest.raises(ValueError, match="Must specify either rfc_string"):
+        truenas_pyscram.ServerFinalMessage(**kwargs)

--- a/tests/test_server_first.py
+++ b/tests/test_server_first.py
@@ -284,3 +284,18 @@ def test_server_first_message_with_different_clients(auth_data, username,
     client_nonce_bytes = bytes(client.nonce)
     combined_nonce_bytes = bytes(msg.nonce)
     assert combined_nonce_bytes.startswith(client_nonce_bytes)
+
+
+def test_server_first_requires_salt(client_first):
+    """salt is required unless rfc_string is given; omitting it raises
+    ValueError."""
+    with pytest.raises(ValueError, match="Must specify either rfc_string"):
+        truenas_pyscram.ServerFirstMessage(client_first=client_first)
+
+
+def test_server_first_rejects_none_salt(client_first):
+    """A salt of None is rejected by the type check, distinct from an
+    omitted argument."""
+    with pytest.raises(TypeError, match="salt must be a CryptoDatum"):
+        truenas_pyscram.ServerFirstMessage(client_first=client_first,
+                                           salt=None, iterations=500000)


### PR DESCRIPTION
ServerFirstMessage, ClientFinalMessage and ServerFinalMessage parse their arguments with an all-optional format, then pass each object to PyObject_IsInstance() -- which dereferences its first argument before any NULL check. Omitting a required keyword (e.g. salt) left that pointer NULL and crashed the interpreter instead of raising.

Require the full creation-argument set in each constructor's presence check, so a missing keyword raises ValueError before any type check runs. Add tests exercising every required argument.

Original PR: https://github.com/truenas/truenas_scram/pull/12
