### PR TITLE
NAS-141928 / 26.0.0-RC.1 / Fix deserializers returning success on incomplete messages (by anodos325)

### DIFF
--- a/src/scram/scram_client_final.c
+++ b/src/scram/scram_client_final.c
@@ -359,6 +359,7 @@ scram_resp_t scram_deserialize_client_final_message(const char *scram_msg_str,
 
 	if (!msg->client_proof.size || !msg->nonce.size) {
 		scram_set_error(error, "missing required attributes");
+		ret = SCRAM_E_PARSE_ERROR;
 		goto cleanup;
 	}
 

--- a/src/scram/scram_client_first.c
+++ b/src/scram/scram_client_first.c
@@ -195,6 +195,7 @@ scram_resp_t scram_deserialize_client_first_message(const char *scram_msg_str,
 
 	if ((*msg->principal.username == '\0') || (msg->nonce.size == 0)) {
 		scram_set_error(error, "missing required attributes");
+		ret = SCRAM_E_PARSE_ERROR;
 		goto cleanup;
 	}
 

--- a/src/scram/scram_server_first.c
+++ b/src/scram/scram_server_first.c
@@ -221,6 +221,7 @@ scram_resp_t scram_deserialize_server_first_message(const char *scram_msg_str,
 
 	if ((msg->nonce.size == 0) || (msg->salt.size == 0) || (msg->iterations == 0)) {
 		scram_set_error(error, "missing required attributes");
+		ret = SCRAM_E_PARSE_ERROR;
 		goto cleanup;
 	}
 

--- a/tests/test_rfc_parsing.py
+++ b/tests/test_rfc_parsing.py
@@ -362,3 +362,59 @@ def test_parse_rejects_equals_in_username():
     bad_rfc = "n,,n=user=name,r=" + "A" * 43
     with pytest.raises(scram.ScramError, match="username must not contain"):
         scram.ClientFirstMessage(rfc_string=bad_rfc)
+
+
+def _truncated(rfc_string, keep):
+    """Drop all but the first `keep` comma-separated attributes of a message."""
+    return ",".join(rfc_string.split(",")[:keep])
+
+
+def _incomplete_messages():
+    """Well-formed-but-incomplete messages: every attribute present parses, but
+    the required set is not satisfied."""
+    client_first = scram.ClientFirstMessage(username="testuser")
+    auth_data = scram.generate_scram_auth_data()
+    server_first = scram.ServerFirstMessage(
+        client_first=client_first,
+        salt=auth_data.salt,
+        iterations=auth_data.iterations
+    )
+    client_final = scram.ClientFinalMessage(
+        client_first=client_first, server_first=server_first,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key
+    )
+
+    # client-first carries a "n,,"-prefixed gs2 header, so its attributes start
+    # at index 1 of the comma split.
+    return [
+        (scram.ClientFirstMessage, _truncated(str(client_first), 3), "no nonce"),
+        (scram.ServerFirstMessage, _truncated(str(server_first), 1), "nonce only"),
+        (scram.ServerFirstMessage, _truncated(str(server_first), 2), "no iterations"),
+        (scram.ClientFinalMessage, _truncated(str(client_final), 2), "no proof"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "msg_type,rfc_string,description",
+    _incomplete_messages(),
+    ids=lambda v: v if isinstance(v, str) and " " in v else None
+)
+def test_parse_rejects_missing_required_attributes(msg_type, rfc_string, description):
+    """A message whose attributes all parse but whose required set is incomplete
+    must be rejected.
+
+    Regression test: the deserializers used to reach the completeness check with
+    `ret` still holding the SCRAM_E_SUCCESS left by the last parsed attribute and
+    jump to cleanup without reassigning it, so they returned SCRAM_E_SUCCESS while
+    leaving *msg_out unwritten. A C caller following the documented
+    `if (ret == SCRAM_E_SUCCESS)` contract then dereferenced an uninitialised
+    pointer. Assert on the specific error so the accidental downstream failure
+    the Python layer used to produce ("invalid input parameters", raised only
+    because the NULL message reached the serializer) cannot pass for a fix.
+    """
+    with pytest.raises(scram.ScramError) as exc_info:
+        msg_type(rfc_string=rfc_string)
+
+    exc = exc_info.value
+    assert "missing required attributes" in str(exc)
+    assert exc.code == scram.SCRAM_E_PARSE_ERROR

--- a/tests/test_rfc_parsing.py
+++ b/tests/test_rfc_parsing.py
@@ -401,17 +401,7 @@ def _incomplete_messages():
 )
 def test_parse_rejects_missing_required_attributes(msg_type, rfc_string, description):
     """A message whose attributes all parse but whose required set is incomplete
-    must be rejected.
-
-    Regression test: the deserializers used to reach the completeness check with
-    `ret` still holding the SCRAM_E_SUCCESS left by the last parsed attribute and
-    jump to cleanup without reassigning it, so they returned SCRAM_E_SUCCESS while
-    leaving *msg_out unwritten. A C caller following the documented
-    `if (ret == SCRAM_E_SUCCESS)` contract then dereferenced an uninitialised
-    pointer. Assert on the specific error so the accidental downstream failure
-    the Python layer used to produce ("invalid input parameters", raised only
-    because the NULL message reached the serializer) cannot pass for a fix.
-    """
+    must be rejected."""
     with pytest.raises(scram.ScramError) as exc_info:
         msg_type(rfc_string=rfc_string)
 


### PR DESCRIPTION
scram_deserialize_{client_first,server_first,client_final}_message reached the "missing required attributes" check with ret still holding the SCRAM_E_SUCCESS left by the last parsed attribute, then jumped to cleanup without resetting it. They returned SCRAM_E_SUCCESS while leaving *msg_out unwritten, so a caller following the documented contract dereferenced an uninitialized pointer.

Set ret = SCRAM_E_PARSE_ERROR before cleanup at each site. Add regression tests asserting the error code and message.

Original PR: https://github.com/truenas/truenas_scram/pull/11
