### PR TITLE
NAS-141932 / 27.0.0-BETA.1 / Make CryptoDatum equality constant-time

### DIFF
--- a/src/pyscram/crypto_datum.c
+++ b/src/pyscram/crypto_datum.c
@@ -165,6 +165,7 @@ py_crypto_datum_richcompare(py_crypto_datum_t *self, PyObject *other, int op)
 	if (self->datum.size != other_datum->datum.size) {
 		result = 0;
 	} else if (self->datum.size == 0) {
+		/* both are zero-length */
 		result = 1;
 	} else {
 		/* Constant-time compare: these datums hold secrets. */

--- a/src/pyscram/crypto_datum.c
+++ b/src/pyscram/crypto_datum.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#include <openssl/crypto.h>
 #include "truenas_pyscram.h"
 
 static int
@@ -150,7 +151,8 @@ py_crypto_datum_richcompare(py_crypto_datum_t *self, PyObject *other, int op)
 		Py_RETURN_NOTIMPLEMENTED;
 	}
 
-	if (!PyObject_IsInstance(other, (PyObject *)&PyCryptoDatum_Type)) {
+	/* Only CryptoDatum instances compare equal; anything else is unequal. */
+	if (!PyObject_TypeCheck(other, &PyCryptoDatum_Type)) {
 		if (op == Py_EQ) {
 			Py_RETURN_FALSE;
 		} else {
@@ -162,8 +164,13 @@ py_crypto_datum_richcompare(py_crypto_datum_t *self, PyObject *other, int op)
 
 	if (self->datum.size != other_datum->datum.size) {
 		result = 0;
+	} else if (self->datum.size == 0) {
+		result = 1;
 	} else {
-		result = (memcmp(self->datum.data, other_datum->datum.data, self->datum.size) == 0);
+		/* Constant-time compare: these datums hold secrets. */
+		result = (CRYPTO_memcmp(self->datum.data,
+					other_datum->datum.data,
+					self->datum.size) == 0);
 	}
 
 	if (op == Py_EQ) {
@@ -208,9 +215,10 @@ static PyMethodDef py_crypto_datum_methods[] = {
 PyDoc_STRVAR(py_crypto_datum__doc__,
 "CryptoDatum(data)\n"
 "-----------------\n\n"
-"Wrapper around crypto_datum_t, subclassing bytes.\n"
-"Provides access to the underlying crypto_datum_t structure\n"
-"while maintaining all bytes functionality.\n\n"
+"Immutable wrapper around a crypto_datum_t holding secret bytes.\n"
+"Supports len(), indexing and slicing, the buffer protocol (e.g.\n"
+"bytes(d)), hashing, and equality against other CryptoDatum instances\n"
+"(constant-time). Call clear() to zero the contents when done.\n\n"
 "Parameters\n"
 "----------\n"
 "data : bytes-like\n"

--- a/tests/test_nonce.py
+++ b/tests/test_nonce.py
@@ -110,3 +110,15 @@ def test_memoryview_reads_zeros_after_clear():
     assert bytes(view) == b"A" * 32
     datum.clear()
     assert bytes(view) == b"\x00" * 32
+
+
+def test_crypto_datum_equality_is_cryptodatum_only():
+    """CryptoDatum compares equal only to another CryptoDatum with the same
+    contents, not to a plain bytes value of the same bytes."""
+    a = truenas_pyscram.CryptoDatum(b"same-secret-value")
+    b = truenas_pyscram.CryptoDatum(b"same-secret-value")
+    c = truenas_pyscram.CryptoDatum(b"another-secret!!!")
+    assert a == b
+    assert a != c
+    assert not (a == b"same-secret-value")
+    assert a != b"same-secret-value"


### PR DESCRIPTION
CryptoDatum wraps secrets (keys, proofs, signatures), but __eq__ compared their contents with plain memcmp, whose data-dependent early exit leaks a byte-at-a-time timing oracle -- the C core already uses CRYPTO_memcmp for exactly these values.

Compare with CRYPTO_memcmp instead. Two related cleanups in the same path: use PyObject_TypeCheck rather than PyObject_IsInstance, whose -1 error return was treated as a match; and correct the type docstring, which claimed CryptoDatum subclasses bytes (it does not) -- equality remains defined only against other CryptoDatum instances.

This is not used explicitly in TrueNAS (cryptographic comparisons happen internally in library), but it's good hygiene to
make sure that someone naively comparing two crypto blobs via `==` will have it done in constant time.