### PR TITLE
NAS-141937 / 27.0.0-BETA.1 / Harden SCRAM attribute parsing

### DIFF
--- a/src/scram/scram_attr_parse.c
+++ b/src/scram/scram_attr_parse.c
@@ -24,7 +24,7 @@ scram_resp_t scram_parse_str_u64(const char *str_in,
 
 	// strtoull requires explicitly setting errno to zero
 	errno = 0;
-	lval = strtoull(str_in, &end, 0);
+	lval = strtoull(str_in, &end, 10);
 	if (errno != 0) {
 		scram_set_error(error, "%s: strtoull() failed: %s",
 				str_in, strerror(errno));
@@ -32,13 +32,13 @@ scram_resp_t scram_parse_str_u64(const char *str_in,
 	}
 
 	/*
-	 * If there were no digits at all then end == str_in
-	 * If all characters were digits then *end will be '\0'
-	 * Otherwise *end will be the first invalid character.
+	 * RFC 5802 numbers are decimal digits only. strtoull() with base 10
+	 * still silently consumes a leading sign or whitespace, so require the
+	 * first character to be a digit; require *end == '\0' to reject any
+	 * trailing characters after the digits.
 	 */
-	if ((end == str_in) && (*end != '\0')) {
-		scram_set_error(error, "%s: not an integer: %c",
-				str_in, *end);
+	if ((str_in[0] < '0' || str_in[0] > '9') || (*end != '\0')) {
+		scram_set_error(error, "%s: not a valid decimal integer", str_in);
 		return SCRAM_E_INVALID_REQUEST;
 	}
 
@@ -227,8 +227,9 @@ scram_resp_t scram_attr_parse(const char *str_in,
 		return SCRAM_E_PARSE_ERROR;
 	}
 
-	// advance attr value past the `=` character
-	if (*attr_val++ == '\0') {
+	// advance past the '=' to the value, then reject an empty value
+	attr_val++;
+	if (*attr_val == '\0') {
 		scram_set_error(error, "%s: expected value after separator", str_in);
 		free(attr_ident);
 		return SCRAM_E_PARSE_ERROR;
@@ -244,11 +245,21 @@ scram_resp_t scram_attr_parse(const char *str_in,
 		}
 		break;
 	case SCRAM_ATTR_SALT_CH:
-		ret = scram_parse_b64_datum(attr_val, SCRAM_DEFAULT_SALT_SZ,
+		/* RFC 5802 sets no salt length; accept any size up to the cap. */
+		ret = scram_parse_b64_datum(attr_val, 0,
 					    &attr_out->scram_val.datum,
 					    error);
 		if (ret == SCRAM_E_SUCCESS) {
-			attr_out->scram_type = ATTR_TYPE_CRYPTO_DATUM;
+			if (attr_out->scram_val.datum.size > SCRAM_MAX_SALT_SZ) {
+				scram_set_error(error,
+						"%zu: salt exceeds maximum of %zu",
+						attr_out->scram_val.datum.size,
+						SCRAM_MAX_SALT_SZ);
+				crypto_datum_clear(&attr_out->scram_val.datum, true);
+				ret = SCRAM_E_INVALID_REQUEST;
+			} else {
+				attr_out->scram_type = ATTR_TYPE_CRYPTO_DATUM;
+			}
 		}
 		break;
 	case SCRAM_ATTR_ITERATION_COUNT_CH:

--- a/src/scram/scram_private.h
+++ b/src/scram/scram_private.h
@@ -61,6 +61,13 @@ SCRAM_ATTR(RESERVED_MEXT, 'm')
 #define SCRAM_DEFAULT_SALT_SZ 16
 #define SCRAM_DEFAULT_PWD_SZ 64
 
+/*
+ * RFC 5802 sets no salt length. Accept any length up to this generous cap
+ * (well above any real salt) when parsing an untrusted server-first-message,
+ * rather than the decoder's 64 KiB ceiling.
+ */
+#define SCRAM_MAX_SALT_SZ ((size_t)1024)
+
 enum scram_attr_type {
 	ATTR_TYPE_NUMBER,
 	ATTR_TYPE_CRYPTO_DATUM,

--- a/tests/test_rfc_parsing.py
+++ b/tests/test_rfc_parsing.py
@@ -1,5 +1,7 @@
 """Tests for RFC string parsing functionality in SCRAM messages."""
 
+import re
+
 import pytest
 import truenas_pyscram as scram
 
@@ -454,3 +456,48 @@ def test_server_final_rfc_string_rejects_extra_param(client_server_first_message
                        match="Cannot specify both rfc_string and other parameters"):
         scram.ServerFinalMessage(rfc_string=str(server_final),
                                  server_key=auth_data.server_key)
+
+def _server_first_str(iterations=500000, salt=None):
+    """Build a server-first-message RFC string for mutation."""
+    client_first = scram.ClientFirstMessage(username="testuser")
+    if salt is None:
+        salt = scram.CryptoDatum(b"S" * 16)
+    return str(scram.ServerFirstMessage(client_first=client_first,
+                                        salt=salt, iterations=iterations))
+
+
+@pytest.mark.parametrize("bad", ["100000junk", "0x186A0", "+100000",
+                                 "100000.5", " 100000", "1e9"])
+def test_server_first_rejects_non_decimal_iterations(bad):
+    """RFC 5802 iteration-count is decimal digits only; a sign, whitespace,
+    hex form, or trailing characters must be rejected."""
+    rfc = re.sub(r"i=\d+$", "i=" + bad, _server_first_str())
+    with pytest.raises(scram.ScramError, match="not a valid decimal integer") as exc:
+        scram.ServerFirstMessage(rfc_string=rfc)
+    assert exc.value.code == scram.SCRAM_E_INVALID_REQUEST
+
+
+@pytest.mark.parametrize("attr", ["i", "s"])
+def test_server_first_rejects_empty_attribute_value(attr):
+    """An attribute present with an empty value (e.g. 'i=' or 's=') is rejected."""
+    base = _server_first_str()
+    rfc = re.sub(r"i=\d+$", "i=", base) if attr == "i" else re.sub(r"s=[^,]+", "s=", base)
+    with pytest.raises(scram.ScramError, match="expected value after separator") as exc:
+        scram.ServerFirstMessage(rfc_string=rfc)
+    assert exc.value.code == scram.SCRAM_E_PARSE_ERROR
+
+
+@pytest.mark.parametrize("salt_len", [16, 32, 64, 1024])
+def test_server_first_accepts_salt_up_to_cap(salt_len):
+    """RFC 5802 sets no salt length; sizes up to the cap round-trip."""
+    rfc = _server_first_str(salt=scram.CryptoDatum(b"S" * salt_len))
+    assert bytes(scram.ServerFirstMessage(rfc_string=rfc).salt) == b"S" * salt_len
+
+
+@pytest.mark.parametrize("salt_len", [1025, 4096])
+def test_server_first_rejects_salt_over_cap(salt_len):
+    """A salt larger than the cap is rejected."""
+    rfc = _server_first_str(salt=scram.CryptoDatum(b"S" * salt_len))
+    with pytest.raises(scram.ScramError, match="salt exceeds maximum") as exc:
+        scram.ServerFirstMessage(rfc_string=rfc)
+    assert exc.value.code == scram.SCRAM_E_INVALID_REQUEST


### PR DESCRIPTION
Three fixes in scram_attr_parse.c, all in how a single attribute value is parsed from an untrusted message:

- Numeric attributes (iteration count, api-key id) were parsed with strtoull base 0 and a guard that ANDed its two reject conditions, so "100000junk", "0x186A0", "+100000" and " 100000" were all initially accepted. They are now rejected earlier.

- The empty-value guard tested the '=' character itself before advancing, so it never fired; "i=" and "s=" reached the per-type parsers. Advance first, then reject an empty value.

- The salt parser required exactly 16 bytes, rejecting server-first messages built from any other salt length (RFC 5802 sets none). Accept any length up to SCRAM_MAX_SALT_SZ (1024), well above any real salt while refusing an absurd one from a malicious peer.