### PR TITLE
NAS-141941 / 27.0.0-BETA.1 / Fix README examples and server-final-message doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Client                                Server
 
 #### 1. Client First Message
 ```python
-client_first = truenas_pyscram.ClientFirstMessage("username")
+client_first = truenas_pyscram.ClientFirstMessage(username="username")
 # Generates: n,,n=username,r=<client_nonce>
 ```
 
@@ -54,22 +54,25 @@ client_first = truenas_pyscram.ClientFirstMessage("username")
 ```python
 auth_data = truenas_pyscram.generate_scram_auth_data()
 server_first = truenas_pyscram.ServerFirstMessage(
-    client_first, auth_data.salt, auth_data.iterations)
+    client_first=client_first, salt=auth_data.salt,
+    iterations=auth_data.iterations)
 # Generates: r=<combined_nonce>,s=<salt_b64>,i=<iterations>
 ```
 
 #### 3. Client Final Message
 ```python
 client_final = truenas_pyscram.ClientFinalMessage(
-    client_first, server_first, auth_data.client_key, auth_data.stored_key)
+    client_first=client_first, server_first=server_first,
+    client_key=auth_data.client_key, stored_key=auth_data.stored_key)
 # Generates: c=<channel_binding_b64>,r=<nonce>,p=<client_proof_b64>
 ```
 
 #### 4. Server Final Message
 ```python
 server_final = truenas_pyscram.ServerFinalMessage(
-    client_first, server_first, client_final,
-    auth_data.stored_key, auth_data.server_key)
+    client_first=client_first, server_first=server_first,
+    client_final=client_final, stored_key=auth_data.stored_key,
+    server_key=auth_data.server_key)
 # Generates: v=<server_signature_b64>
 ```
 
@@ -79,14 +82,17 @@ server_final = truenas_pyscram.ServerFinalMessage(
 ```python
 # Server verifies client authentication
 truenas_pyscram.verify_client_final_message(
-    client_first, server_first, client_final, stored_key)
+    client_first=client_first, server_first=server_first,
+    client_final=client_final, stored_key=stored_key)
 ```
 
 #### Client-Side Verification (Optional but Recommended)
 ```python
 # Client verifies server authenticity
 truenas_pyscram.verify_server_signature(
-    client_first, server_first, client_final, server_final, server_key)
+    client_first=client_first, server_first=server_first,
+    client_final=client_final, server_final=server_final,
+    server_key=server_key)
 ```
 
 ## Complete Example
@@ -98,28 +104,33 @@ import truenas_pyscram
 auth_data = truenas_pyscram.generate_scram_auth_data()
 
 # 1. Client creates first message
-client_first = truenas_pyscram.ClientFirstMessage("alice")
+client_first = truenas_pyscram.ClientFirstMessage(username="alice")
 
 # 2. Server creates first response
 server_first = truenas_pyscram.ServerFirstMessage(
-    client_first, auth_data.salt, auth_data.iterations)
+    client_first=client_first, salt=auth_data.salt,
+    iterations=auth_data.iterations)
 
 # 3. Client creates final message (with password-derived keys)
 client_final = truenas_pyscram.ClientFinalMessage(
-    client_first, server_first, auth_data.client_key, auth_data.stored_key)
+    client_first=client_first, server_first=server_first,
+    client_key=auth_data.client_key, stored_key=auth_data.stored_key)
 
 # 4. Server verifies client and creates final response
 truenas_pyscram.verify_client_final_message(
-    client_first, server_first, client_final, auth_data.stored_key)
+    client_first=client_first, server_first=server_first,
+    client_final=client_final, stored_key=auth_data.stored_key)
 
 server_final = truenas_pyscram.ServerFinalMessage(
-    client_first, server_first, client_final,
-    auth_data.stored_key, auth_data.server_key)
+    client_first=client_first, server_first=server_first,
+    client_final=client_final, stored_key=auth_data.stored_key,
+    server_key=auth_data.server_key)
 
 # 5. Client verifies server (optional but recommended)
 truenas_pyscram.verify_server_signature(
-    client_first, server_first, client_final, server_final,
-    auth_data.server_key)
+    client_first=client_first, server_first=server_first,
+    client_final=client_final, server_final=server_final,
+    server_key=auth_data.server_key)
 
 print("Authentication successful!")
 ```

--- a/src/scram/truenas_scram.h
+++ b/src/scram/truenas_scram.h
@@ -488,10 +488,16 @@ scram_resp_t scram_create_server_first_message(const scram_client_first_t *clien
  * as defined in RFC 5802 Section 3. It generates the server signature by
  * reconstructing the AuthMessage and calculating ServerSignature = HMAC(ServerKey, AuthMessage).
  *
+ * This function does NOT verify the client's proof; the caller must do that
+ * separately with scram_verify_client_final_message() before trusting the
+ * client-final-message passed here.
+ *
  * @param[in] cfirst - client first message structure
  * @param[in] sfirst - server first message structure
  * @param[in] cfinal - client final message structure
- * @param[in] stored_key - stored key for verification
+ * @param[in] stored_key - the user's StoredKey; validated but not used by this
+ *            function (the signature needs only server_key), kept for symmetry
+ *            with the verification API
  * @param[in] server_key - server key for generating server signature
  * @param[out] msg_out - allocated server final message structure
  * @param[in,out] error - error buffer for detailed error information


### PR DESCRIPTION
The README quickstart called the message constructors positionally, but they are keyword-only, so every example raised TypeError. Use keyword arguments throughout (the Complete Example now runs end to end).

Correct the scram_create_server_final_message() header comment: it documented stored_key as "for verification", but the function does not verify the client proof and never reads stored_key -- the signature uses only server_key. Say so, and point callers at scram_verify_client_final_message().