### PR TITLE
NAS-141940 / 26.0.0-BETA.3 / Use PyObject_TypeCheck for argument type checks (by anodos325)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Client                                Server
 
 #### 1. Client First Message
 ```python
-client_first = truenas_pyscram.ClientFirstMessage("username")
+client_first = truenas_pyscram.ClientFirstMessage(username="username")
 # Generates: n,,n=username,r=<client_nonce>
 ```
 
@@ -54,22 +54,25 @@ client_first = truenas_pyscram.ClientFirstMessage("username")
 ```python
 auth_data = truenas_pyscram.generate_scram_auth_data()
 server_first = truenas_pyscram.ServerFirstMessage(
-    client_first, auth_data.salt, auth_data.iterations)
+    client_first=client_first, salt=auth_data.salt,
+    iterations=auth_data.iterations)
 # Generates: r=<combined_nonce>,s=<salt_b64>,i=<iterations>
 ```
 
 #### 3. Client Final Message
 ```python
 client_final = truenas_pyscram.ClientFinalMessage(
-    client_first, server_first, auth_data.client_key, auth_data.stored_key)
+    client_first=client_first, server_first=server_first,
+    client_key=auth_data.client_key, stored_key=auth_data.stored_key)
 # Generates: c=<channel_binding_b64>,r=<nonce>,p=<client_proof_b64>
 ```
 
 #### 4. Server Final Message
 ```python
 server_final = truenas_pyscram.ServerFinalMessage(
-    client_first, server_first, client_final,
-    auth_data.stored_key, auth_data.server_key)
+    client_first=client_first, server_first=server_first,
+    client_final=client_final, stored_key=auth_data.stored_key,
+    server_key=auth_data.server_key)
 # Generates: v=<server_signature_b64>
 ```
 
@@ -79,14 +82,17 @@ server_final = truenas_pyscram.ServerFinalMessage(
 ```python
 # Server verifies client authentication
 truenas_pyscram.verify_client_final_message(
-    client_first, server_first, client_final, stored_key)
+    client_first=client_first, server_first=server_first,
+    client_final=client_final, stored_key=stored_key)
 ```
 
 #### Client-Side Verification (Optional but Recommended)
 ```python
 # Client verifies server authenticity
 truenas_pyscram.verify_server_signature(
-    client_first, server_first, client_final, server_final, server_key)
+    client_first=client_first, server_first=server_first,
+    client_final=client_final, server_final=server_final,
+    server_key=server_key)
 ```
 
 ## Complete Example
@@ -98,28 +104,33 @@ import truenas_pyscram
 auth_data = truenas_pyscram.generate_scram_auth_data()
 
 # 1. Client creates first message
-client_first = truenas_pyscram.ClientFirstMessage("alice")
+client_first = truenas_pyscram.ClientFirstMessage(username="alice")
 
 # 2. Server creates first response
 server_first = truenas_pyscram.ServerFirstMessage(
-    client_first, auth_data.salt, auth_data.iterations)
+    client_first=client_first, salt=auth_data.salt,
+    iterations=auth_data.iterations)
 
 # 3. Client creates final message (with password-derived keys)
 client_final = truenas_pyscram.ClientFinalMessage(
-    client_first, server_first, auth_data.client_key, auth_data.stored_key)
+    client_first=client_first, server_first=server_first,
+    client_key=auth_data.client_key, stored_key=auth_data.stored_key)
 
 # 4. Server verifies client and creates final response
 truenas_pyscram.verify_client_final_message(
-    client_first, server_first, client_final, auth_data.stored_key)
+    client_first=client_first, server_first=server_first,
+    client_final=client_final, stored_key=auth_data.stored_key)
 
 server_final = truenas_pyscram.ServerFinalMessage(
-    client_first, server_first, client_final,
-    auth_data.stored_key, auth_data.server_key)
+    client_first=client_first, server_first=server_first,
+    client_final=client_final, stored_key=auth_data.stored_key,
+    server_key=auth_data.server_key)
 
 # 5. Client verifies server (optional but recommended)
 truenas_pyscram.verify_server_signature(
-    client_first, server_first, client_final, server_final,
-    auth_data.server_key)
+    client_first=client_first, server_first=server_first,
+    client_final=client_final, server_final=server_final,
+    server_key=auth_data.server_key)
 
 print("Authentication successful!")
 ```

--- a/src/pyscram/py_client_final.c
+++ b/src/pyscram/py_client_final.c
@@ -51,8 +51,8 @@ parse_client_final_params(PyObject *args, PyObject *kwds,
 	}
 
 	/* Validate client_first parameter */
-	if (!PyObject_IsInstance(client_first_obj,
-				 (PyObject *)&PyClientFirstMessage_Type)) {
+	if (!PyObject_TypeCheck(client_first_obj,
+				 &PyClientFirstMessage_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"client_first must be a ClientFirstMessage instance");
 		return -1;
@@ -60,8 +60,8 @@ parse_client_final_params(PyObject *args, PyObject *kwds,
 	params->client_first = (py_client_first_t *)client_first_obj;
 
 	/* Validate server_first parameter */
-	if (!PyObject_IsInstance(server_first_obj,
-				 (PyObject *)&PyServerFirstMessage_Type)) {
+	if (!PyObject_TypeCheck(server_first_obj,
+				 &PyServerFirstMessage_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"server_first must be a ServerFirstMessage instance");
 		return -1;
@@ -69,8 +69,8 @@ parse_client_final_params(PyObject *args, PyObject *kwds,
 	params->server_first = (py_server_first_t *)server_first_obj;
 
 	/* Validate client_key parameter */
-	if (!PyObject_IsInstance(client_key_obj,
-				 (PyObject *)&PyCryptoDatum_Type)) {
+	if (!PyObject_TypeCheck(client_key_obj,
+				 &PyCryptoDatum_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"client_key must be a CryptoDatum instance");
 		return -1;
@@ -78,8 +78,8 @@ parse_client_final_params(PyObject *args, PyObject *kwds,
 	params->client_key = (py_crypto_datum_t *)client_key_obj;
 
 	/* Validate stored_key parameter */
-	if (!PyObject_IsInstance(stored_key_obj,
-				 (PyObject *)&PyCryptoDatum_Type)) {
+	if (!PyObject_TypeCheck(stored_key_obj,
+				 &PyCryptoDatum_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"stored_key must be a CryptoDatum instance");
 		return -1;
@@ -88,8 +88,8 @@ parse_client_final_params(PyObject *args, PyObject *kwds,
 
 	/* Validate optional channel_binding parameter */
 	if (channel_binding_obj && channel_binding_obj != Py_None) {
-		if (!PyObject_IsInstance(channel_binding_obj,
-					 (PyObject *)&PyCryptoDatum_Type)) {
+		if (!PyObject_TypeCheck(channel_binding_obj,
+					 &PyCryptoDatum_Type)) {
 			PyErr_SetString(PyExc_TypeError,
 					"channel_binding must be a CryptoDatum instance or None");
 			return -1;

--- a/src/pyscram/py_scram_verify.c
+++ b/src/pyscram/py_scram_verify.c
@@ -42,8 +42,8 @@ parse_client_final_verify_params(PyObject *args, PyObject *kwds,
 	}
 
 	/* Validate client_first parameter */
-	if (!PyObject_IsInstance(client_first_obj,
-				 (PyObject *)&PyClientFirstMessage_Type)) {
+	if (!PyObject_TypeCheck(client_first_obj,
+				 &PyClientFirstMessage_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"client_first must be a ClientFirstMessage instance");
 		return -1;
@@ -51,8 +51,8 @@ parse_client_final_verify_params(PyObject *args, PyObject *kwds,
 	params->client_first = (py_client_first_t *)client_first_obj;
 
 	/* Validate server_first parameter */
-	if (!PyObject_IsInstance(server_first_obj,
-				 (PyObject *)&PyServerFirstMessage_Type)) {
+	if (!PyObject_TypeCheck(server_first_obj,
+				 &PyServerFirstMessage_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"server_first must be a ServerFirstMessage instance");
 		return -1;
@@ -60,8 +60,8 @@ parse_client_final_verify_params(PyObject *args, PyObject *kwds,
 	params->server_first = (py_server_first_t *)server_first_obj;
 
 	/* Validate client_final parameter */
-	if (!PyObject_IsInstance(client_final_obj,
-				 (PyObject *)&PyClientFinalMessage_Type)) {
+	if (!PyObject_TypeCheck(client_final_obj,
+				 &PyClientFinalMessage_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"client_final must be a ClientFinalMessage instance");
 		return -1;
@@ -69,8 +69,8 @@ parse_client_final_verify_params(PyObject *args, PyObject *kwds,
 	params->client_final = (py_client_final_t *)client_final_obj;
 
 	/* Validate stored_key parameter */
-	if (!PyObject_IsInstance(stored_key_obj,
-				 (PyObject *)&PyCryptoDatum_Type)) {
+	if (!PyObject_TypeCheck(stored_key_obj,
+				 &PyCryptoDatum_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"stored_key must be a CryptoDatum instance");
 		return -1;
@@ -105,8 +105,8 @@ parse_client_final_verify_params(PyObject *args, PyObject *kwds,
 	/* Optional channel binding: a CryptoDatum (SCRAM-PLUS) or None */
 	params->channel_binding = NULL;
 	if (channel_binding_obj && channel_binding_obj != Py_None) {
-		if (!PyObject_IsInstance(channel_binding_obj,
-					 (PyObject *)&PyCryptoDatum_Type)) {
+		if (!PyObject_TypeCheck(channel_binding_obj,
+					 &PyCryptoDatum_Type)) {
 			PyErr_SetString(PyExc_TypeError,
 					"channel_binding must be a CryptoDatum or None");
 			return -1;
@@ -138,8 +138,8 @@ parse_server_signature_verify_params(PyObject *args, PyObject *kwds,
 	}
 
 	/* Validate client_first parameter */
-	if (!PyObject_IsInstance(client_first_obj,
-				 (PyObject *)&PyClientFirstMessage_Type)) {
+	if (!PyObject_TypeCheck(client_first_obj,
+				 &PyClientFirstMessage_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"client_first must be a ClientFirstMessage instance");
 		return -1;
@@ -147,8 +147,8 @@ parse_server_signature_verify_params(PyObject *args, PyObject *kwds,
 	params->client_first = (py_client_first_t *)client_first_obj;
 
 	/* Validate server_first parameter */
-	if (!PyObject_IsInstance(server_first_obj,
-				 (PyObject *)&PyServerFirstMessage_Type)) {
+	if (!PyObject_TypeCheck(server_first_obj,
+				 &PyServerFirstMessage_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"server_first must be a ServerFirstMessage instance");
 		return -1;
@@ -156,8 +156,8 @@ parse_server_signature_verify_params(PyObject *args, PyObject *kwds,
 	params->server_first = (py_server_first_t *)server_first_obj;
 
 	/* Validate client_final parameter */
-	if (!PyObject_IsInstance(client_final_obj,
-				 (PyObject *)&PyClientFinalMessage_Type)) {
+	if (!PyObject_TypeCheck(client_final_obj,
+				 &PyClientFinalMessage_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"client_final must be a ClientFinalMessage instance");
 		return -1;
@@ -165,8 +165,8 @@ parse_server_signature_verify_params(PyObject *args, PyObject *kwds,
 	params->client_final = (py_client_final_t *)client_final_obj;
 
 	/* Validate server_final parameter */
-	if (!PyObject_IsInstance(server_final_obj,
-				 (PyObject *)&PyServerFinalMessage_Type)) {
+	if (!PyObject_TypeCheck(server_final_obj,
+				 &PyServerFinalMessage_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"server_final must be a ServerFinalMessage instance");
 		return -1;
@@ -174,8 +174,8 @@ parse_server_signature_verify_params(PyObject *args, PyObject *kwds,
 	params->server_final = (py_server_final_t *)server_final_obj;
 
 	/* Validate server_key parameter */
-	if (!PyObject_IsInstance(server_key_obj,
-				 (PyObject *)&PyCryptoDatum_Type)) {
+	if (!PyObject_TypeCheck(server_key_obj,
+				 &PyCryptoDatum_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"server_key must be a CryptoDatum instance");
 		return -1;

--- a/src/pyscram/py_server_final.c
+++ b/src/pyscram/py_server_final.c
@@ -52,8 +52,8 @@ parse_server_final_params(PyObject *args, PyObject *kwds,
 	}
 
 	/* Validate client_first parameter */
-	if (!PyObject_IsInstance(client_first_obj,
-				 (PyObject *)&PyClientFirstMessage_Type)) {
+	if (!PyObject_TypeCheck(client_first_obj,
+				 &PyClientFirstMessage_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"client_first must be a ClientFirstMessage instance");
 		return -1;
@@ -61,8 +61,8 @@ parse_server_final_params(PyObject *args, PyObject *kwds,
 	params->client_first = (py_client_first_t *)client_first_obj;
 
 	/* Validate server_first parameter */
-	if (!PyObject_IsInstance(server_first_obj,
-				 (PyObject *)&PyServerFirstMessage_Type)) {
+	if (!PyObject_TypeCheck(server_first_obj,
+				 &PyServerFirstMessage_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"server_first must be a ServerFirstMessage instance");
 		return -1;
@@ -70,8 +70,8 @@ parse_server_final_params(PyObject *args, PyObject *kwds,
 	params->server_first = (py_server_first_t *)server_first_obj;
 
 	/* Validate client_final parameter */
-	if (!PyObject_IsInstance(client_final_obj,
-				 (PyObject *)&PyClientFinalMessage_Type)) {
+	if (!PyObject_TypeCheck(client_final_obj,
+				 &PyClientFinalMessage_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"client_final must be a ClientFinalMessage instance");
 		return -1;
@@ -79,8 +79,8 @@ parse_server_final_params(PyObject *args, PyObject *kwds,
 	params->client_final = (py_client_final_t *)client_final_obj;
 
 	/* Validate stored_key parameter */
-	if (!PyObject_IsInstance(stored_key_obj,
-				 (PyObject *)&PyCryptoDatum_Type)) {
+	if (!PyObject_TypeCheck(stored_key_obj,
+				 &PyCryptoDatum_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"stored_key must be a CryptoDatum instance");
 		return -1;
@@ -88,8 +88,8 @@ parse_server_final_params(PyObject *args, PyObject *kwds,
 	params->stored_key = (py_crypto_datum_t *)stored_key_obj;
 
 	/* Validate server_key parameter */
-	if (!PyObject_IsInstance(server_key_obj,
-				 (PyObject *)&PyCryptoDatum_Type)) {
+	if (!PyObject_TypeCheck(server_key_obj,
+				 &PyCryptoDatum_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"server_key must be a CryptoDatum instance");
 		return -1;

--- a/src/pyscram/py_server_first.c
+++ b/src/pyscram/py_server_first.c
@@ -64,14 +64,14 @@ py_server_first_init(py_server_first_t *self, PyObject *args, PyObject *kwds)
 	}
 
 	/* Create new message from parameters */
-	if (!PyObject_IsInstance(client_first_obj,
-				 (PyObject *)&PyClientFirstMessage_Type)) {
+	if (!PyObject_TypeCheck(client_first_obj,
+				 &PyClientFirstMessage_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"client_first must be a ClientFirstMessage instance");
 		return -1;
 	}
 
-	if (!PyObject_IsInstance(salt_obj, (PyObject *)&PyCryptoDatum_Type)) {
+	if (!PyObject_TypeCheck(salt_obj, &PyCryptoDatum_Type)) {
 		PyErr_SetString(PyExc_TypeError,
 				"salt must be a CryptoDatum instance");
 		return -1;

--- a/src/pyscram/truenas_pyscram.c
+++ b/src/pyscram/truenas_pyscram.c
@@ -146,7 +146,7 @@ py_generate_scram_auth_data(PyObject *self, PyObject *args, PyObject *kwds)
 
 	/* Validate and extract salted_password if provided */
 	if (salted_password_obj && salted_password_obj != Py_None) {
-		if (!PyObject_IsInstance(salted_password_obj, (PyObject *)&PyCryptoDatum_Type)) {
+		if (!PyObject_TypeCheck(salted_password_obj, &PyCryptoDatum_Type)) {
 			PyErr_SetString(PyExc_TypeError, "salted_password must be a CryptoDatum");
 			return NULL;
 		}
@@ -155,7 +155,7 @@ py_generate_scram_auth_data(PyObject *self, PyObject *args, PyObject *kwds)
 
 	/* Validate and extract salt if provided */
 	if (salt_obj && salt_obj != Py_None) {
-		if (!PyObject_IsInstance(salt_obj, (PyObject *)&PyCryptoDatum_Type)) {
+		if (!PyObject_TypeCheck(salt_obj, &PyCryptoDatum_Type)) {
 			PyErr_SetString(PyExc_TypeError, "salt must be a CryptoDatum");
 			return NULL;
 		}

--- a/src/scram/truenas_scram.h
+++ b/src/scram/truenas_scram.h
@@ -488,10 +488,16 @@ scram_resp_t scram_create_server_first_message(const scram_client_first_t *clien
  * as defined in RFC 5802 Section 3. It generates the server signature by
  * reconstructing the AuthMessage and calculating ServerSignature = HMAC(ServerKey, AuthMessage).
  *
+ * This function does NOT verify the client's proof; the caller must do that
+ * separately with scram_verify_client_final_message() before trusting the
+ * client-final-message passed here.
+ *
  * @param[in] cfirst - client first message structure
  * @param[in] sfirst - server first message structure
  * @param[in] cfinal - client final message structure
- * @param[in] stored_key - stored key for verification
+ * @param[in] stored_key - the user's StoredKey; validated but not used by this
+ *            function (the signature needs only server_key), kept for symmetry
+ *            with the verification API
  * @param[in] server_key - server key for generating server signature
  * @param[out] msg_out - allocated server final message structure
  * @param[in,out] error - error buffer for detailed error information


### PR DESCRIPTION
PyObject_IsInstance() returns -1 on error, and every call site tested it as a boolean -- !PyObject_IsInstance(...) is 0 for a -1 return, so an error would be misread as "is an instance" and the object cast and dereferenced with an exception already set. These checks target the extension's own concrete types, which are not subclassable and define no `__instancecheck__`, so PyObject_TypeCheck() -- which cannot fail -- is the correct and cheaper primitive.

Convert the 24 remaining call sites across the argument parsers; the PyModule_AddObjectRef() type casts are unaffected. No behavior change for valid or wrong-typed arguments.

Original PR: https://github.com/truenas/truenas_scram/pull/25
