### PR TITLE
NAS-141938 / 26.0.0-RC.1 / Reject rfc_string combined with any message parameter (by anodos325)

### DIFF
--- a/src/pyscram/py_client_final.c
+++ b/src/pyscram/py_client_final.c
@@ -31,7 +31,8 @@ parse_client_final_params(PyObject *args, PyObject *kwds,
 	}
 
 	/* Check for mutually exclusive parameters */
-	if (*rfc_string && client_first_obj) {
+	if (*rfc_string && (client_first_obj || server_first_obj || client_key_obj ||
+			    stored_key_obj || channel_binding_obj)) {
 		PyErr_SetString(PyExc_ValueError,
 				"Cannot specify both rfc_string and other parameters");
 		return -1;

--- a/src/pyscram/py_client_first.c
+++ b/src/pyscram/py_client_first.c
@@ -49,6 +49,12 @@ py_client_first_init(py_client_first_t *self, PyObject *args, PyObject *kwds)
 		return -1;
 	}
 
+	if (rfc_string && api_key_id) {
+		PyErr_SetString(PyExc_ValueError,
+				"Cannot specify both rfc_string and api_key_id parameters");
+		return -1;
+	}
+
 	if (channel_binding_type && gs2_header) {
 		PyErr_SetString(PyExc_ValueError,
 				"Cannot specify both gs2_header and channel_binding_type parameters");

--- a/src/pyscram/py_server_final.c
+++ b/src/pyscram/py_server_final.c
@@ -31,7 +31,8 @@ parse_server_final_params(PyObject *args, PyObject *kwds,
 	}
 
 	/* Check for mutually exclusive parameters */
-	if (*rfc_string && client_first_obj) {
+	if (*rfc_string && (client_first_obj || server_first_obj || client_final_obj ||
+			    stored_key_obj || server_key_obj)) {
 		PyErr_SetString(PyExc_ValueError,
 				"Cannot specify both rfc_string and other parameters");
 		return -1;

--- a/tests/test_rfc_parsing.py
+++ b/tests/test_rfc_parsing.py
@@ -408,3 +408,49 @@ def test_parse_rejects_missing_required_attributes(msg_type, rfc_string, descrip
     exc = exc_info.value
     assert "missing required attributes" in str(exc)
     assert exc.code == scram.SCRAM_E_PARSE_ERROR
+
+
+def test_client_first_rfc_string_api_key_id_exclusive():
+    """rfc_string and api_key_id are mutually exclusive (api_key_id would
+    otherwise be silently ignored)."""
+    cf = scram.ClientFirstMessage(username="testuser")
+    with pytest.raises(ValueError,
+                       match="Cannot specify both rfc_string and api_key_id"):
+        scram.ClientFirstMessage(rfc_string=str(cf), api_key_id=99)
+
+
+@pytest.mark.parametrize("extra", ["server_first", "client_key",
+                                   "stored_key", "channel_binding"])
+def test_client_final_rfc_string_rejects_any_extra_param(
+        client_server_first_messages, extra):
+    """rfc_string cannot be combined with any message parameter, not just the
+    first one checked."""
+    client_first, server_first, auth_data = client_server_first_messages
+    final = scram.ClientFinalMessage(
+        client_first=client_first, server_first=server_first,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key)
+    values = {
+        "server_first": server_first,
+        "client_key": auth_data.client_key,
+        "stored_key": auth_data.stored_key,
+        "channel_binding": scram.CryptoDatum(b"x" * 32),
+    }
+    with pytest.raises(ValueError,
+                       match="Cannot specify both rfc_string and other parameters"):
+        scram.ClientFinalMessage(rfc_string=str(final), **{extra: values[extra]})
+
+
+def test_server_final_rfc_string_rejects_extra_param(client_server_first_messages):
+    """rfc_string cannot be combined with a non-first message parameter."""
+    client_first, server_first, auth_data = client_server_first_messages
+    client_final = scram.ClientFinalMessage(
+        client_first=client_first, server_first=server_first,
+        client_key=auth_data.client_key, stored_key=auth_data.stored_key)
+    server_final = scram.ServerFinalMessage(
+        client_first=client_first, server_first=server_first,
+        client_final=client_final, stored_key=auth_data.stored_key,
+        server_key=auth_data.server_key)
+    with pytest.raises(ValueError,
+                       match="Cannot specify both rfc_string and other parameters"):
+        scram.ServerFinalMessage(rfc_string=str(server_final),
+                                 server_key=auth_data.server_key)


### PR DESCRIPTION
The rfc_string mutual-exclusion guards checked only the first companion argument, so ClientFinalMessage(rfc_string=..., channel_binding=cb) and similar calls were accepted and then silently ignored everything but rfc_string -- e.g. the channel binding was dropped, or a passed api_key_id came back as 0. A caller who thinks it attached data to a parsed message got a message without it and no error.

Check rfc_string against the full set of message parameters in each constructor: the two *FinalMessage parsers now test every object argument, and ClientFirstMessage adds the missing api_key_id check.

Original PR: https://github.com/truenas/truenas_scram/pull/24
